### PR TITLE
feat: Alertmanager webhook integration

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -155,6 +155,68 @@ data: Deployment complete.
 }
 ```
 
+## POST /webhooks/alertmanager - Alertmanager Webhook
+
+Receives Alertmanager webhook payloads and creates tasks for each alert.
+
+**Task Resolution:** For each alert, the task name is resolved in order:
+1. `alert.labels.aqsh_task`
+2. `commonLabels.aqsh_task`
+3. `alert.labels.alertname`
+
+**Environment Variables:** Each task receives alert context as env vars:
+
+| Variable | Source |
+|----------|--------|
+| `ALERT_STATUS` | alert status (firing/resolved) |
+| `ALERT_NAME` | alertname label |
+| `ALERT_INSTANCE` | instance label |
+| `ALERT_SEVERITY` | severity label |
+| `ALERT_FINGERPRINT` | alert fingerprint |
+| `ALERT_STARTS_AT` | alert start time |
+| `ALERT_ENDS_AT` | alert end time |
+| `ALERT_GENERATOR_URL` | Prometheus generator URL |
+| `ALERT_LABELS_JSON` | all labels as JSON |
+| `ALERT_ANNOTATIONS_JSON` | all annotations as JSON |
+| `ALERTMANAGER_EXTERNAL_URL` | Alertmanager URL |
+| `ALERT_GROUP_KEY` | group key |
+| `ALERT_LABEL_<KEY>` | each label (key uppercased) |
+| `ALERT_ANNOTATION_<KEY>` | each annotation (key uppercased) |
+
+**Request:**
+```http
+POST /webhooks/alertmanager
+Content-Type: application/json
+
+{
+  "version": "4",
+  "status": "firing",
+  "groupKey": "{}:{alertname=\"HighMemory\"}",
+  "commonLabels": {"alertname": "HighMemory", "aqsh_task": "alert-handler"},
+  "externalURL": "http://alertmanager:9093",
+  "alerts": [{
+    "status": "firing",
+    "labels": {"alertname": "HighMemory", "aqsh_task": "alert-handler", "instance": "web-1", "severity": "critical"},
+    "annotations": {"summary": "Memory usage is high"},
+    "startsAt": "2024-01-01T00:00:00Z",
+    "endsAt": "0001-01-01T00:00:00Z",
+    "fingerprint": "abc123"
+  }]
+}
+```
+
+**Response (202 Accepted):** At least one alert was successfully enqueued.
+```json
+{
+  "results": [
+    {"alert_fingerprint": "abc123", "task_id": "...", "task_name": "alert-handler", "status": "pending"},
+    {"alert_fingerprint": "def456", "error": "unknown task: nonexistent"}
+  ]
+}
+```
+
+**Response (400 Bad Request):** All alerts failed or invalid payload.
+
 ## GET /health - Health Check
 
 **Response (200 OK):**

--- a/docs/api.md
+++ b/docs/api.md
@@ -209,8 +209,7 @@ Content-Type: application/json
 ```json
 {
   "results": [
-    {"alert_fingerprint": "abc123", "task_id": "...", "task_name": "alert-handler", "status": "pending"},
-    {"alert_fingerprint": "def456", "error": "unknown task: nonexistent"}
+    {"alert_fingerprint": "abc123", "task_id": "...", "task_name": "alert-handler", "status": "pending"}
   ]
 }
 ```

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -334,7 +334,15 @@ func (s *Server) handleAlertmanagerWebhook(w http.ResponseWriter, r *http.Reques
 			CreatedAt: time.Now(),
 			Env:       env,
 		}
-		taskBytes, _ := json.Marshal(taskPayload)
+		taskBytes, err := json.Marshal(taskPayload)
+		if err != nil {
+			log.Printf("Webhook: failed to marshal task payload: %v", err)
+			results = append(results, alertResult{
+				AlertFingerprint: alert.Fingerprint,
+				Error:            "internal error",
+			})
+			continue
+		}
 
 		task := asynq.NewTask(worker.TaskType, taskBytes,
 			asynq.Queue(taskDef.Queue),

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rophy/aqsh/internal/config"
 	"github.com/rophy/aqsh/internal/logs"
 	"github.com/rophy/aqsh/internal/tasks"
+	"github.com/rophy/aqsh/internal/webhook"
 	"github.com/rophy/aqsh/internal/worker"
 )
 
@@ -62,6 +63,7 @@ func (s *Server) Run(ctx context.Context) error {
 	mux.HandleFunc("GET /tasks/{id}/logs", s.handleGetLogs)
 	mux.HandleFunc("GET /tasks", s.handleListTasks)
 	mux.HandleFunc("GET /health", s.handleHealth)
+	mux.HandleFunc("POST /webhooks/alertmanager", s.handleAlertmanagerWebhook)
 	mux.Handle("GET /metrics", promhttp.Handler())
 
 	// Coverage endpoint - only available when GOCOVERDIR is set
@@ -280,6 +282,93 @@ func (s *Server) handleGetLogs(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+func (s *Server) handleAlertmanagerWebhook(w http.ResponseWriter, r *http.Request) {
+	var wh webhook.AlertmanagerWebhook
+	if err := json.NewDecoder(r.Body).Decode(&wh); err != nil {
+		s.jsonError(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+
+	if len(wh.Alerts) == 0 {
+		s.jsonError(w, http.StatusBadRequest, "no alerts in payload")
+		return
+	}
+
+	type alertResult struct {
+		AlertFingerprint string `json:"alert_fingerprint"`
+		TaskID           string `json:"task_id,omitempty"`
+		TaskName         string `json:"task_name,omitempty"`
+		Status           string `json:"status,omitempty"`
+		Error            string `json:"error,omitempty"`
+	}
+
+	results := make([]alertResult, 0, len(wh.Alerts))
+	successCount := 0
+
+	for _, alert := range wh.Alerts {
+		taskName := webhook.ResolveTaskName(alert, wh.CommonLabels)
+		if taskName == "" {
+			results = append(results, alertResult{
+				AlertFingerprint: alert.Fingerprint,
+				Error:            "no task name resolved",
+			})
+			continue
+		}
+
+		taskDef, err := s.tasks.Resolve(taskName)
+		if err != nil {
+			log.Printf("Webhook: unknown task %q for alert %s", taskName, alert.Fingerprint)
+			results = append(results, alertResult{
+				AlertFingerprint: alert.Fingerprint,
+				Error:            "unknown task: " + taskName,
+			})
+			continue
+		}
+
+		env := webhook.AlertToEnv(alert, wh)
+
+		taskPayload := worker.TaskPayload{
+			Name:      taskName,
+			CreatedAt: time.Now(),
+			Env:       env,
+		}
+		taskBytes, _ := json.Marshal(taskPayload)
+
+		task := asynq.NewTask(worker.TaskType, taskBytes,
+			asynq.Queue(taskDef.Queue),
+			asynq.Timeout(taskDef.Timeout),
+			asynq.MaxRetry(taskDef.MaxRetry),
+			asynq.Retention(s.cfg.ResultRetention),
+		)
+
+		info, err := s.client.Enqueue(task)
+		if err != nil {
+			log.Printf("Webhook: failed to enqueue task %q: %v", taskName, err)
+			results = append(results, alertResult{
+				AlertFingerprint: alert.Fingerprint,
+				Error:            "enqueue failed: " + err.Error(),
+			})
+			continue
+		}
+
+		log.Printf("Webhook: enqueued task %q (id=%s) for alert %s", taskName, info.ID, alert.Fingerprint)
+		successCount++
+		results = append(results, alertResult{
+			AlertFingerprint: alert.Fingerprint,
+			TaskID:           info.ID,
+			TaskName:         taskName,
+			Status:           "pending",
+		})
+	}
+
+	if successCount == 0 {
+		s.jsonResponse(w, http.StatusBadRequest, map[string]any{"results": results})
+		return
+	}
+
+	s.jsonResponse(w, http.StatusAccepted, map[string]any{"results": results})
 }
 
 func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {

--- a/internal/webhook/alertmanager.go
+++ b/internal/webhook/alertmanager.go
@@ -8,13 +8,16 @@ import (
 
 // AlertmanagerWebhook represents the payload sent by Alertmanager webhook receiver.
 type AlertmanagerWebhook struct {
-	Version      string            `json:"version"`
-	GroupKey     string            `json:"groupKey"`
-	Status       string            `json:"status"`
-	Receiver     string            `json:"receiver"`
-	ExternalURL  string            `json:"externalURL"`
-	CommonLabels map[string]string `json:"commonLabels"`
-	Alerts       []Alert           `json:"alerts"`
+	Version           string            `json:"version"`
+	GroupKey          string            `json:"groupKey"`
+	Status            string            `json:"status"`
+	Receiver          string            `json:"receiver"`
+	ExternalURL       string            `json:"externalURL"`
+	CommonLabels      map[string]string `json:"commonLabels"`
+	CommonAnnotations map[string]string `json:"commonAnnotations"`
+	GroupLabels       map[string]string `json:"groupLabels"`
+	TruncatedAlerts   int               `json:"truncatedAlerts"`
+	Alerts            []Alert           `json:"alerts"`
 }
 
 // Alert represents a single alert in the Alertmanager webhook payload.
@@ -45,7 +48,7 @@ var envKeyRegexp = regexp.MustCompile(`[^A-Z0-9_]`)
 // sanitizeEnvKey converts a string to a valid env var key component.
 // Only [A-Z0-9_] are allowed.
 func sanitizeEnvKey(key string) string {
-	return envKeyRegexp.ReplaceAllString(strings.ToUpper(strings.ReplaceAll(key, "-", "_")), "")
+	return envKeyRegexp.ReplaceAllString(strings.ToUpper(key), "_")
 }
 
 // AlertToEnv converts an alert and its parent webhook into a map of environment variables.

--- a/internal/webhook/alertmanager.go
+++ b/internal/webhook/alertmanager.go
@@ -1,0 +1,85 @@
+package webhook
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// AlertmanagerWebhook represents the payload sent by Alertmanager webhook receiver.
+type AlertmanagerWebhook struct {
+	Version      string            `json:"version"`
+	GroupKey     string            `json:"groupKey"`
+	Status       string            `json:"status"`
+	Receiver     string            `json:"receiver"`
+	ExternalURL  string            `json:"externalURL"`
+	CommonLabels map[string]string `json:"commonLabels"`
+	Alerts       []Alert           `json:"alerts"`
+}
+
+// Alert represents a single alert in the Alertmanager webhook payload.
+type Alert struct {
+	Status       string            `json:"status"`
+	Labels       map[string]string `json:"labels"`
+	Annotations  map[string]string `json:"annotations"`
+	StartsAt     string            `json:"startsAt"`
+	EndsAt       string            `json:"endsAt"`
+	GeneratorURL string            `json:"generatorURL"`
+	Fingerprint  string            `json:"fingerprint"`
+}
+
+// ResolveTaskName determines the aqsh task name for an alert.
+// Lookup order: alert.Labels["aqsh_task"] -> commonLabels["aqsh_task"] -> alert.Labels["alertname"]
+func ResolveTaskName(alert Alert, commonLabels map[string]string) string {
+	if t := alert.Labels["aqsh_task"]; t != "" {
+		return t
+	}
+	if t := commonLabels["aqsh_task"]; t != "" {
+		return t
+	}
+	return alert.Labels["alertname"]
+}
+
+var envKeyRegexp = regexp.MustCompile(`[^A-Z0-9_]`)
+
+// sanitizeEnvKey converts a string to a valid env var key component.
+// Only [A-Z0-9_] are allowed.
+func sanitizeEnvKey(key string) string {
+	return envKeyRegexp.ReplaceAllString(strings.ToUpper(strings.ReplaceAll(key, "-", "_")), "")
+}
+
+// AlertToEnv converts an alert and its parent webhook into a map of environment variables.
+func AlertToEnv(alert Alert, wh AlertmanagerWebhook) map[string]string {
+	env := map[string]string{
+		"ALERT_STATUS":             alert.Status,
+		"ALERT_NAME":               alert.Labels["alertname"],
+		"ALERT_INSTANCE":           alert.Labels["instance"],
+		"ALERT_SEVERITY":           alert.Labels["severity"],
+		"ALERT_FINGERPRINT":        alert.Fingerprint,
+		"ALERT_STARTS_AT":          alert.StartsAt,
+		"ALERT_ENDS_AT":            alert.EndsAt,
+		"ALERT_GENERATOR_URL":      alert.GeneratorURL,
+		"ALERTMANAGER_EXTERNAL_URL": wh.ExternalURL,
+		"ALERT_GROUP_KEY":          wh.GroupKey,
+	}
+
+	// Serialize labels and annotations as JSON
+	if labelsJSON, err := json.Marshal(alert.Labels); err == nil {
+		env["ALERT_LABELS_JSON"] = string(labelsJSON)
+	}
+	if annotationsJSON, err := json.Marshal(alert.Annotations); err == nil {
+		env["ALERT_ANNOTATIONS_JSON"] = string(annotationsJSON)
+	}
+
+	// Expand individual labels as ALERT_LABEL_<KEY>
+	for k, v := range alert.Labels {
+		env["ALERT_LABEL_"+sanitizeEnvKey(k)] = v
+	}
+
+	// Expand individual annotations as ALERT_ANNOTATION_<KEY>
+	for k, v := range alert.Annotations {
+		env["ALERT_ANNOTATION_"+sanitizeEnvKey(k)] = v
+	}
+
+	return env
+}

--- a/internal/webhook/alertmanager_test.go
+++ b/internal/webhook/alertmanager_test.go
@@ -1,0 +1,159 @@
+package webhook
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestResolveTaskName(t *testing.T) {
+	tests := []struct {
+		name         string
+		alert        Alert
+		commonLabels map[string]string
+		want         string
+	}{
+		{
+			name: "aqsh_task from alert labels",
+			alert: Alert{
+				Labels: map[string]string{"aqsh_task": "restart-pod", "alertname": "HighMemory"},
+			},
+			commonLabels: map[string]string{"aqsh_task": "common-task"},
+			want:         "restart-pod",
+		},
+		{
+			name: "fallback to commonLabels aqsh_task",
+			alert: Alert{
+				Labels: map[string]string{"alertname": "HighMemory"},
+			},
+			commonLabels: map[string]string{"aqsh_task": "common-task"},
+			want:         "common-task",
+		},
+		{
+			name: "fallback to alertname",
+			alert: Alert{
+				Labels: map[string]string{"alertname": "HighMemory"},
+			},
+			commonLabels: map[string]string{},
+			want:         "HighMemory",
+		},
+		{
+			name: "nil commonLabels falls back to alertname",
+			alert: Alert{
+				Labels: map[string]string{"alertname": "DiskFull"},
+			},
+			commonLabels: nil,
+			want:         "DiskFull",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ResolveTaskName(tt.alert, tt.commonLabels)
+			if got != tt.want {
+				t.Errorf("ResolveTaskName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAlertToEnv(t *testing.T) {
+	alert := Alert{
+		Status: "firing",
+		Labels: map[string]string{
+			"alertname": "HighMemory",
+			"instance":  "web-1",
+			"severity":  "critical",
+			"app-name":  "frontend",
+		},
+		Annotations: map[string]string{
+			"summary":     "Memory usage is high",
+			"description": "Instance web-1 memory > 90%",
+		},
+		StartsAt:     "2024-01-01T00:00:00Z",
+		EndsAt:       "0001-01-01T00:00:00Z",
+		GeneratorURL: "http://prometheus:9090/graph",
+		Fingerprint:  "abc123",
+	}
+
+	wh := AlertmanagerWebhook{
+		ExternalURL: "http://alertmanager:9093",
+		GroupKey:    "{}:{alertname=\"HighMemory\"}",
+	}
+
+	env := AlertToEnv(alert, wh)
+
+	// Check fixed fields
+	checks := map[string]string{
+		"ALERT_STATUS":              "firing",
+		"ALERT_NAME":                "HighMemory",
+		"ALERT_INSTANCE":            "web-1",
+		"ALERT_SEVERITY":            "critical",
+		"ALERT_FINGERPRINT":         "abc123",
+		"ALERT_STARTS_AT":           "2024-01-01T00:00:00Z",
+		"ALERT_ENDS_AT":             "0001-01-01T00:00:00Z",
+		"ALERT_GENERATOR_URL":       "http://prometheus:9090/graph",
+		"ALERTMANAGER_EXTERNAL_URL": "http://alertmanager:9093",
+		"ALERT_GROUP_KEY":           "{}:{alertname=\"HighMemory\"}",
+	}
+
+	for key, want := range checks {
+		if got := env[key]; got != want {
+			t.Errorf("env[%q] = %q, want %q", key, got, want)
+		}
+	}
+
+	// Check JSON fields
+	var labels map[string]string
+	if err := json.Unmarshal([]byte(env["ALERT_LABELS_JSON"]), &labels); err != nil {
+		t.Fatalf("ALERT_LABELS_JSON unmarshal error: %v", err)
+	}
+	if labels["alertname"] != "HighMemory" {
+		t.Errorf("ALERT_LABELS_JSON alertname = %q, want %q", labels["alertname"], "HighMemory")
+	}
+
+	var annotations map[string]string
+	if err := json.Unmarshal([]byte(env["ALERT_ANNOTATIONS_JSON"]), &annotations); err != nil {
+		t.Fatalf("ALERT_ANNOTATIONS_JSON unmarshal error: %v", err)
+	}
+	if annotations["summary"] != "Memory usage is high" {
+		t.Errorf("ALERT_ANNOTATIONS_JSON summary = %q, want %q", annotations["summary"], "Memory usage is high")
+	}
+
+	// Check expanded labels (ALERT_LABEL_<KEY>)
+	if got := env["ALERT_LABEL_ALERTNAME"]; got != "HighMemory" {
+		t.Errorf("env[ALERT_LABEL_ALERTNAME] = %q, want %q", got, "HighMemory")
+	}
+	if got := env["ALERT_LABEL_APP_NAME"]; got != "frontend" {
+		t.Errorf("env[ALERT_LABEL_APP_NAME] = %q, want %q (hyphen should become underscore)", got, "frontend")
+	}
+
+	// Check expanded annotations (ALERT_ANNOTATION_<KEY>)
+	if got := env["ALERT_ANNOTATION_SUMMARY"]; got != "Memory usage is high" {
+		t.Errorf("env[ALERT_ANNOTATION_SUMMARY] = %q, want %q", got, "Memory usage is high")
+	}
+}
+
+func TestSanitizeEnvKey(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"alertname", "ALERTNAME"},
+		{"app-name", "APP_NAME"},
+		{"my.label.key", "MYLABELKEY"},
+		{"ALREADY_UPPER", "ALREADY_UPPER"},
+		{"with spaces", "WITHSPACES"},
+		{"special!@#chars", "SPECIALCHARS"},
+		{"under_score", "UNDER_SCORE"},
+		{"123numeric", "123NUMERIC"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sanitizeEnvKey(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeEnvKey(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/webhook/alertmanager_test.go
+++ b/internal/webhook/alertmanager_test.go
@@ -44,6 +44,12 @@ func TestResolveTaskName(t *testing.T) {
 			commonLabels: nil,
 			want:         "DiskFull",
 		},
+		{
+			name:         "empty when no labels at all",
+			alert:        Alert{Labels: map[string]string{}},
+			commonLabels: nil,
+			want:         "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -140,10 +146,10 @@ func TestSanitizeEnvKey(t *testing.T) {
 	}{
 		{"alertname", "ALERTNAME"},
 		{"app-name", "APP_NAME"},
-		{"my.label.key", "MYLABELKEY"},
+		{"my.label.key", "MY_LABEL_KEY"},
 		{"ALREADY_UPPER", "ALREADY_UPPER"},
-		{"with spaces", "WITHSPACES"},
-		{"special!@#chars", "SPECIALCHARS"},
+		{"with spaces", "WITH_SPACES"},
+		{"special!@#chars", "SPECIAL___CHARS"},
 		{"under_score", "UNDER_SCORE"},
 		{"123numeric", "123NUMERIC"},
 	}

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -65,3 +65,17 @@ tasks:
     timeout: 1m
     max_retry: 0
     input: []
+
+  alert-handler:
+    script: alert-handler.sh
+    description: "Handle Alertmanager alerts (auto-healing)"
+    timeout: 5m
+    max_retry: 1
+    input: []
+
+  latency-handler:
+    script: latency-handler.sh
+    description: "Handle high latency alerts"
+    timeout: 5m
+    max_retry: 1
+    input: []

--- a/tasks/alert-handler.sh
+++ b/tasks/alert-handler.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "Alert: $ALERT_NAME ($ALERT_STATUS)"
+echo "Instance: $ALERT_INSTANCE"
+echo "Severity: $ALERT_SEVERITY"
+echo "Fingerprint: $ALERT_FINGERPRINT"
+
+if [ "$ALERT_STATUS" = "resolved" ]; then
+    echo "Alert resolved, no action needed"
+    exit 0
+fi
+
+echo "Processing remediation for $ALERT_NAME..."
+# Actual remediation logic goes here
+echo "Remediation complete"
+echo "Task logs available at: GET /tasks/$AQSH_TASK_ID/logs"

--- a/tasks/latency-handler.sh
+++ b/tasks/latency-handler.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "Latency Alert: $ALERT_NAME ($ALERT_STATUS)"
+echo "Instance: $ALERT_INSTANCE"
+echo "Severity: $ALERT_SEVERITY"
+
+if [ "$ALERT_STATUS" = "resolved" ]; then
+    echo "Latency alert resolved"
+    exit 0
+fi
+
+echo "Investigating high latency on $ALERT_INSTANCE..."
+echo "Latency remediation complete"


### PR DESCRIPTION
## Summary

Adds `POST /webhooks/alertmanager` endpoint that receives [Alertmanager webhook payloads](https://prometheus.io/docs/alerting/latest/configuration/#webhook_config) and automatically enqueues aqsh tasks for each alert.

- **Task routing**: resolves task name via `aqsh_task` label → `commonLabels.aqsh_task` → `alertname` fallback
- **Alert context**: maps alert labels/annotations to `ALERT_*` environment variables for scripts
- **Multi-alert handling**: each alert in a group is enqueued as a separate task

## Changes (7 files, +436 lines)

| File | Description |
|------|-------------|
| `internal/webhook/alertmanager.go` | Payload structs, `ResolveTaskName()`, `AlertToEnv()` |
| `internal/webhook/alertmanager_test.go` | 11 unit tests covering routing, env mapping, edge cases |
| `internal/api/api.go` | `handleAlertmanagerWebhook()` handler + route registration |
| `docs/api.md` | Webhook endpoint documentation |
| `tasks.yaml` | `alert-handler` + `latency-handler` task definitions |
| `tasks/alert-handler.sh` | Demo remediation script |
| `tasks/latency-handler.sh` | Demo latency handler script |

## Testing

- 11 new unit tests for the webhook package
- All 44 existing + new tests pass (`go test ./...`)

## Demo

The included `alert-handler.sh` and `latency-handler.sh` scripts demonstrate how alert context flows into task scripts via environment variables:

```bash
# alert-handler.sh receives:
# ALERT_STATUS=firing, ALERT_NAME=HighMemory, ALERT_SEVERITY=critical, etc.
```

## Example Alertmanager config

```yaml
receivers:
  - name: aqsh-webhook
    webhook_configs:
      - url: 'http://aqsh:8080/webhooks/alertmanager'
        send_resolved: true
```

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alertmanager webhook integration to create tasks from incoming alerts.
  * New alert and latency handler tasks and accompanying remediation scripts.

* **Documentation**
  * Added API docs for the Alertmanager webhook with request/response examples and env mappings.

* **Tests**
  * Unit tests covering alert-to-task name resolution and environment variable generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->