### PR TITLE
feat: add allowed_users per-task authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ tasks:
     description: "Deploy application to environment"
     timeout: 10m
     max_retry: 2
+    allowed_users: [system:serviceaccount:deploy:deployer]
     allowed_groups: [deploy-team, platform-team]
 
     input:
@@ -427,19 +428,23 @@ Set `AQSH_REQUIRE_IDENTITY=true` to reject requests without this header (401).
 
 ### Group Authorization
 
-Tasks can restrict access to specific groups using `allowed_groups` in the task config:
+Tasks can restrict access using `allowed_users` and/or `allowed_groups` in the task config:
 
 ```yaml
 tasks:
   deploy:
     script: /tasks/deploy.sh
+    allowed_users: [system:serviceaccount:deploy:deployer]
     allowed_groups: [deploy-team, platform-team]
     input: [...]
 ```
 
-The proxy sets `X-Forwarded-Groups` (configurable via `AQSH_GROUPS_HEADER`) as a comma-separated list. If a task has `allowed_groups`, aqsh checks that at least one of the user's groups matches. Returns 403 if no match.
+- `allowed_users` matches the identity header against the list (exact match).
+- `allowed_groups` matches the groups header (comma-separated) against the list.
+- If both are set, the request is authorized if **either** matches (OR logic). This mirrors Kubernetes RBAC `RoleBinding.subjects` semantics.
+- Returns 403 if neither matches.
 
-Tasks without `allowed_groups` are open to all users (or all authenticated users when `AQSH_REQUIRE_IDENTITY=true`).
+Tasks without `allowed_users` or `allowed_groups` are open to all users (or all authenticated users when `AQSH_REQUIRE_IDENTITY=true`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ The proxy sets `X-Forwarded-User` (configurable via `AQSH_IDENTITY_HEADER`) on a
 
 Set `AQSH_REQUIRE_IDENTITY=true` to reject requests without this header (401).
 
-### Group Authorization
+### User and Group Authorization
 
 Tasks can restrict access using `allowed_users` and/or `allowed_groups` in the task config:
 
@@ -445,6 +445,10 @@ tasks:
 - Returns 403 if neither matches.
 
 Tasks without `allowed_users` or `allowed_groups` are open to all users (or all authenticated users when `AQSH_REQUIRE_IDENTITY=true`).
+
+### Trust Boundary
+
+aqsh trusts `X-Forwarded-User` and `X-Forwarded-Groups` headers set by the authenticating reverse proxy. Clients that reach aqsh directly can forge these headers and bypass authorization. Ensure aqsh only accepts traffic from the auth proxy — e.g., via Kubernetes NetworkPolicy, localhost-only binding, or a sidecar proxy.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,9 +18,9 @@ X-Forwarded-User: alice@example.com
 
 The identity header (default `X-Forwarded-User`, configurable via `AQSH_IDENTITY_HEADER`) identifies who submitted the task. When `AQSH_REQUIRE_IDENTITY=true`, requests without this header are rejected with 401.
 
-**Group Authorization:**
+**Authorization:**
 
-Tasks with `allowed_groups` in their config require the groups header (default `X-Forwarded-Groups`, configurable via `AQSH_GROUPS_HEADER`) to contain at least one matching group. Groups are comma-separated.
+Tasks can restrict access using `allowed_users` and/or `allowed_groups` in their config. If either matches, the request is authorized (OR logic). `allowed_users` matches against the identity header; `allowed_groups` matches against the groups header (comma-separated). If neither is configured, the task is open to all.
 
 **Response (202 Accepted):**
 ```json
@@ -35,7 +35,7 @@ Tasks with `allowed_groups` in their config require the groups header (default `
 | Status | Reason |
 |--------|--------|
 | 401 | Missing identity header (when `AQSH_REQUIRE_IDENTITY=true`) |
-| 403 | Not authorized for this task (group check failed) |
+| 403 | Not authorized for this task (user/group check failed) |
 | 400 | Validation error (missing field, invalid pattern, etc.) |
 | 404 | Unknown task |
 | 503 | Redis unavailable |

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -441,8 +441,11 @@ func splitGroups(header string) []string {
 }
 
 func isAllowedUser(identity string, allowedUsers []string) bool {
+	if identity == "" {
+		return false
+	}
 	for _, u := range allowedUsers {
-		if identity == u {
+		if u != "" && identity == u {
 			return true
 		}
 	}

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -146,10 +146,12 @@ func (s *Server) handleSubmitTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Group authorization
+	// Authorization: allowed_users OR allowed_groups
 	groups := r.Header.Get(s.cfg.GroupsHeader)
-	if len(taskDef.AllowedGroups) > 0 {
-		if !hasAnyGroup(splitGroups(groups), taskDef.AllowedGroups) {
+	if len(taskDef.AllowedUsers) > 0 || len(taskDef.AllowedGroups) > 0 {
+		userOK := len(taskDef.AllowedUsers) > 0 && isAllowedUser(identity, taskDef.AllowedUsers)
+		groupOK := len(taskDef.AllowedGroups) > 0 && hasAnyGroup(splitGroups(groups), taskDef.AllowedGroups)
+		if !userOK && !groupOK {
 			s.jsonError(w, http.StatusForbidden, "not authorized for this task")
 			return
 		}
@@ -370,6 +372,9 @@ func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 		if len(taskDef.AllowedGroups) > 0 {
 			taskInfo["allowed_groups"] = taskDef.AllowedGroups
 		}
+		if len(taskDef.AllowedUsers) > 0 {
+			taskInfo["allowed_users"] = taskDef.AllowedUsers
+		}
 		result[name] = taskInfo
 	}
 
@@ -433,6 +438,15 @@ func splitGroups(header string) []string {
 		}
 	}
 	return groups
+}
+
+func isAllowedUser(identity string, allowedUsers []string) bool {
+	for _, u := range allowedUsers {
+		if identity == u {
+			return true
+		}
+	}
+	return false
 }
 
 func hasAnyGroup(userGroups, allowedGroups []string) bool {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -694,6 +694,7 @@ func TestHandleSubmitTaskGroupAuthorization(t *testing.T) {
 		logStream: logs.NewLogStreamer(rdb, time.Hour),
 		client:    asynq.NewClient(asynq.RedisClientOpt{Addr: mr.Addr()}),
 	}
+	defer s.client.Close()
 
 	t.Run("allowed group passes", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/tasks/restricted", strings.NewReader(`{}`))
@@ -788,6 +789,7 @@ func TestHandleSubmitTaskUserAuthorization(t *testing.T) {
 		logStream: logs.NewLogStreamer(rdb, time.Hour),
 		client:    asynq.NewClient(asynq.RedisClientOpt{Addr: mr.Addr()}),
 	}
+	defer s.client.Close()
 
 	t.Run("allowed user passes", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/tasks/sa-only", strings.NewReader(`{}`))

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -881,6 +881,7 @@ func TestIsAllowedUser(t *testing.T) {
 		{"no match", "charlie", []string{"alice", "bob"}, false},
 		{"empty identity", "", []string{"alice"}, false},
 		{"empty identity empty allowed", "", []string{""}, false},
+		{"non-empty identity empty allowed entry", "alice", []string{""}, false},
 		{"empty allowed", "alice", nil, false},
 		{"exact SA match", "system:serviceaccount:rdsma:sertdxkkk", []string{"system:serviceaccount:rdsma:sertdxkkk"}, true},
 	}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -759,6 +759,141 @@ func TestHandleSubmitTaskGroupAuthorization(t *testing.T) {
 	})
 }
 
+func TestHandleSubmitTaskUserAuthorization(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	tasksConfig := &tasks.TasksConfig{
+		Tasks: map[string]tasks.TaskDef{
+			"sa-only": {
+				Script:       "sa.sh",
+				AllowedUsers: []string{"system:serviceaccount:rdsma:sertdxkkk"},
+			},
+			"users-and-groups": {
+				Script:        "both.sh",
+				AllowedUsers:  []string{"alice"},
+				AllowedGroups: []string{"ops"},
+			},
+		},
+	}
+
+	s := &Server{
+		cfg: &config.Config{
+			IdentityHeader: "X-Forwarded-User",
+			GroupsHeader:   "X-Forwarded-Groups",
+		},
+		tasks:     tasksConfig,
+		rdb:       rdb,
+		logStream: logs.NewLogStreamer(rdb, time.Hour),
+		client:    asynq.NewClient(asynq.RedisClientOpt{Addr: mr.Addr()}),
+	}
+
+	t.Run("allowed user passes", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/sa-only", strings.NewReader(`{}`))
+		req.SetPathValue("name", "sa-only")
+		req.Header.Set("X-Forwarded-User", "system:serviceaccount:rdsma:sertdxkkk")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Errorf("expected status %d, got %d: %s", http.StatusAccepted, rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("wrong user returns 403", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/sa-only", strings.NewReader(`{}`))
+		req.SetPathValue("name", "sa-only")
+		req.Header.Set("X-Forwarded-User", "system:serviceaccount:other:other")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+		}
+	})
+
+	t.Run("no identity returns 403 for user-restricted task", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/sa-only", strings.NewReader(`{}`))
+		req.SetPathValue("name", "sa-only")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+		}
+	})
+
+	t.Run("user match passes even without matching group", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/users-and-groups", strings.NewReader(`{}`))
+		req.SetPathValue("name", "users-and-groups")
+		req.Header.Set("X-Forwarded-User", "alice")
+		req.Header.Set("X-Forwarded-Groups", "dev")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Errorf("expected status %d, got %d: %s", http.StatusAccepted, rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("group match passes even without matching user", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/users-and-groups", strings.NewReader(`{}`))
+		req.SetPathValue("name", "users-and-groups")
+		req.Header.Set("X-Forwarded-User", "bob")
+		req.Header.Set("X-Forwarded-Groups", "ops")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Errorf("expected status %d, got %d: %s", http.StatusAccepted, rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("neither user nor group match returns 403", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/users-and-groups", strings.NewReader(`{}`))
+		req.SetPathValue("name", "users-and-groups")
+		req.Header.Set("X-Forwarded-User", "bob")
+		req.Header.Set("X-Forwarded-Groups", "dev")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+		}
+	})
+}
+
+func TestIsAllowedUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		identity string
+		allowed  []string
+		expected bool
+	}{
+		{"match", "alice", []string{"alice", "bob"}, true},
+		{"no match", "charlie", []string{"alice", "bob"}, false},
+		{"empty identity", "", []string{"alice"}, false},
+		{"empty allowed", "alice", nil, false},
+		{"exact SA match", "system:serviceaccount:rdsma:sertdxkkk", []string{"system:serviceaccount:rdsma:sertdxkkk"}, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isAllowedUser(tc.identity, tc.allowed)
+			if got != tc.expected {
+				t.Errorf("isAllowedUser(%q, %v) = %v, want %v", tc.identity, tc.allowed, got, tc.expected)
+			}
+		})
+	}
+}
+
 func TestSplitGroups(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -880,6 +880,7 @@ func TestIsAllowedUser(t *testing.T) {
 		{"match", "alice", []string{"alice", "bob"}, true},
 		{"no match", "charlie", []string{"alice", "bob"}, false},
 		{"empty identity", "", []string{"alice"}, false},
+		{"empty identity empty allowed", "", []string{""}, false},
 		{"empty allowed", "alice", nil, false},
 		{"exact SA match", "system:serviceaccount:rdsma:sertdxkkk", []string{"system:serviceaccount:rdsma:sertdxkkk"}, true},
 	}

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -30,8 +30,8 @@ type TaskDef struct {
 	MaxRetry      *int     `yaml:"max_retry"`
 	RetryDelay    string   `yaml:"retry_delay"`
 	Queue         string   `yaml:"queue"`
-	AllowedGroups []string `yaml:"allowed_groups"`
 	AllowedUsers  []string `yaml:"allowed_users"`
+	AllowedGroups []string `yaml:"allowed_groups"`
 	Input         []Input  `yaml:"input"`
 }
 
@@ -161,8 +161,8 @@ type ResolvedTask struct {
 	MaxRetry      int
 	RetryDelay    time.Duration
 	Queue         string
-	AllowedGroups []string
 	AllowedUsers  []string
+	AllowedGroups []string
 	Input         []Input
 }
 
@@ -231,8 +231,8 @@ func (c *TasksConfig) Resolve(name string) (*ResolvedTask, error) {
 		MaxRetry:      maxRetry,
 		RetryDelay:    retryDelayDur,
 		Queue:         queue,
-		AllowedGroups: task.AllowedGroups,
 		AllowedUsers:  task.AllowedUsers,
+		AllowedGroups: task.AllowedGroups,
 		Input:         task.Input,
 	}, nil
 }

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -31,6 +31,7 @@ type TaskDef struct {
 	RetryDelay    string   `yaml:"retry_delay"`
 	Queue         string   `yaml:"queue"`
 	AllowedGroups []string `yaml:"allowed_groups"`
+	AllowedUsers  []string `yaml:"allowed_users"`
 	Input         []Input  `yaml:"input"`
 }
 
@@ -161,6 +162,7 @@ type ResolvedTask struct {
 	RetryDelay    time.Duration
 	Queue         string
 	AllowedGroups []string
+	AllowedUsers  []string
 	Input         []Input
 }
 
@@ -230,6 +232,7 @@ func (c *TasksConfig) Resolve(name string) (*ResolvedTask, error) {
 		RetryDelay:    retryDelayDur,
 		Queue:         queue,
 		AllowedGroups: task.AllowedGroups,
+		AllowedUsers:  task.AllowedUsers,
 		Input:         task.Input,
 	}, nil
 }

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -370,8 +370,11 @@ func TestTasksConfigResolve(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Resolve() error = %v", err)
 		}
-		if len(resolved.AllowedUsers) != 1 || len(resolved.AllowedGroups) != 1 {
-			t.Errorf("expected 1 user and 1 group, got users=%v groups=%v", resolved.AllowedUsers, resolved.AllowedGroups)
+		if len(resolved.AllowedUsers) != 1 || resolved.AllowedUsers[0] != "alice" {
+			t.Errorf("expected AllowedUsers [alice], got %v", resolved.AllowedUsers)
+		}
+		if len(resolved.AllowedGroups) != 1 || resolved.AllowedGroups[0] != "ops" {
+			t.Errorf("expected AllowedGroups [ops], got %v", resolved.AllowedGroups)
 		}
 	})
 }

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -342,6 +342,38 @@ func TestTasksConfigResolve(t *testing.T) {
 			t.Errorf("expected empty AllowedGroups, got %v", resolved.AllowedGroups)
 		}
 	})
+
+	t.Run("resolve allowed_users", func(t *testing.T) {
+		cfg := &TasksConfig{
+			Tasks: map[string]TaskDef{
+				"sa-only": {
+					Script:       "sa.sh",
+					AllowedUsers: []string{"system:serviceaccount:rdsma:sertdxkkk"},
+				},
+				"both": {
+					Script:        "both.sh",
+					AllowedUsers:  []string{"alice"},
+					AllowedGroups: []string{"ops"},
+				},
+			},
+		}
+
+		resolved, err := cfg.Resolve("sa-only")
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+		if len(resolved.AllowedUsers) != 1 || resolved.AllowedUsers[0] != "system:serviceaccount:rdsma:sertdxkkk" {
+			t.Errorf("expected AllowedUsers [system:serviceaccount:rdsma:sertdxkkk], got %v", resolved.AllowedUsers)
+		}
+
+		resolved, err = cfg.Resolve("both")
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+		if len(resolved.AllowedUsers) != 1 || len(resolved.AllowedGroups) != 1 {
+			t.Errorf("expected 1 user and 1 group, got users=%v groups=%v", resolved.AllowedUsers, resolved.AllowedGroups)
+		}
+	})
 }
 
 func TestValidatePayload(t *testing.T) {

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -71,7 +71,7 @@ tasks:
     description: "Task restricted to specific users"
     timeout: 1m
     max_retry: 0
-    allowed_users: ["sa:deploy-bot"]
+    allowed_users: ["system:serviceaccount:default:deploy-bot"]
     input:
       - name: name
         env: NAME
@@ -83,7 +83,7 @@ tasks:
     description: "Task restricted to specific users or groups"
     timeout: 1m
     max_retry: 0
-    allowed_users: ["sa:deploy-bot"]
+    allowed_users: ["system:serviceaccount:default:deploy-bot"]
     allowed_groups: ["ops-team"]
     input:
       - name: name

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -65,3 +65,28 @@ tasks:
     timeout: 1m
     max_retry: 0
     input: []
+
+  user-restricted:
+    script: hello.sh
+    description: "Task restricted to specific users"
+    timeout: 1m
+    max_retry: 0
+    allowed_users: ["sa:deploy-bot"]
+    input:
+      - name: name
+        env: NAME
+        required: true
+        type: string
+
+  user-or-group:
+    script: hello.sh
+    description: "Task restricted to specific users or groups"
+    timeout: 1m
+    max_retry: 0
+    allowed_users: ["sa:deploy-bot"]
+    allowed_groups: ["ops-team"]
+    input:
+      - name: name
+        env: NAME
+        required: true
+        type: string

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -470,7 +470,7 @@ test_allowed_users() {
     # Matching user should be accepted
     HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
         -H "Content-Type: application/json" \
-        -H "X-Forwarded-User: sa:deploy-bot" \
+        -H "X-Forwarded-User: system:serviceaccount:default:deploy-bot" \
         -d '{"name":"test"}' \
         "$BASE_URL/tasks/user-restricted")
 
@@ -483,7 +483,7 @@ test_allowed_users() {
     # Wrong user should be rejected
     HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
         -H "Content-Type: application/json" \
-        -H "X-Forwarded-User: sa:other-bot" \
+        -H "X-Forwarded-User: system:serviceaccount:default:other-bot" \
         -d '{"name":"test"}' \
         "$BASE_URL/tasks/user-restricted")
 
@@ -513,7 +513,7 @@ test_allowed_users_or_groups() {
     # Matching user, no matching group — should pass
     HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
         -H "Content-Type: application/json" \
-        -H "X-Forwarded-User: sa:deploy-bot" \
+        -H "X-Forwarded-User: system:serviceaccount:default:deploy-bot" \
         -H "X-Forwarded-Groups: dev-team" \
         -d '{"name":"test"}' \
         "$BASE_URL/tasks/user-or-group")
@@ -527,7 +527,7 @@ test_allowed_users_or_groups() {
     # Wrong user, matching group — should pass
     HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
         -H "Content-Type: application/json" \
-        -H "X-Forwarded-User: sa:other-bot" \
+        -H "X-Forwarded-User: system:serviceaccount:default:other-bot" \
         -H "X-Forwarded-Groups: ops-team" \
         -d '{"name":"test"}' \
         "$BASE_URL/tasks/user-or-group")
@@ -541,7 +541,7 @@ test_allowed_users_or_groups() {
     # Neither user nor group match — should be rejected
     HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
         -H "Content-Type: application/json" \
-        -H "X-Forwarded-User: sa:other-bot" \
+        -H "X-Forwarded-User: system:serviceaccount:default:other-bot" \
         -H "X-Forwarded-Groups: dev-team" \
         -d '{"name":"test"}' \
         "$BASE_URL/tasks/user-or-group")
@@ -555,13 +555,20 @@ test_allowed_users_or_groups() {
 
 # Test: GET /tasks includes allowed_users in listing
 test_list_tasks_allowed_users() {
-    info "Testing GET /tasks includes allowed_users"
+    info "Testing GET /tasks includes allowed_users for user-restricted task"
     RESP=$(curl -s "$BASE_URL/tasks")
 
-    if echo "$RESP" | grep -q '"allowed_users"'; then
-        pass "GET /tasks includes allowed_users field"
+    # Check that user-restricted task has allowed_users with the expected value
+    if echo "$RESP" | grep -q '"user-restricted"'; then
+        pass "GET /tasks contains user-restricted task"
     else
-        fail "GET /tasks includes allowed_users field" "allowed_users in response" "$RESP"
+        fail "GET /tasks contains user-restricted task" "user-restricted in response" "$RESP"
+    fi
+
+    if echo "$RESP" | grep -q 'system:serviceaccount:default:deploy-bot'; then
+        pass "GET /tasks user-restricted has expected allowed_users value"
+    else
+        fail "GET /tasks user-restricted has expected allowed_users value" "system:serviceaccount:default:deploy-bot" "$RESP"
     fi
 }
 

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -463,6 +463,108 @@ test_task_no_result_file() {
     fi
 }
 
+# Test: allowed_users authorization
+test_allowed_users() {
+    info "Testing allowed_users authorization"
+
+    # Matching user should be accepted
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -H "X-Forwarded-User: sa:deploy-bot" \
+        -d '{"name":"test"}' \
+        "$BASE_URL/tasks/user-restricted")
+
+    if [ "$HTTP_CODE" = "202" ]; then
+        pass "allowed_users: matching user returns 202"
+    else
+        fail "allowed_users: matching user returns 202" "202" "$HTTP_CODE"
+    fi
+
+    # Wrong user should be rejected
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -H "X-Forwarded-User: sa:other-bot" \
+        -d '{"name":"test"}' \
+        "$BASE_URL/tasks/user-restricted")
+
+    if [ "$HTTP_CODE" = "403" ]; then
+        pass "allowed_users: wrong user returns 403"
+    else
+        fail "allowed_users: wrong user returns 403" "403" "$HTTP_CODE"
+    fi
+
+    # No user header should be rejected
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"name":"test"}' \
+        "$BASE_URL/tasks/user-restricted")
+
+    if [ "$HTTP_CODE" = "403" ]; then
+        pass "allowed_users: no user header returns 403"
+    else
+        fail "allowed_users: no user header returns 403" "403" "$HTTP_CODE"
+    fi
+}
+
+# Test: allowed_users OR allowed_groups (combined)
+test_allowed_users_or_groups() {
+    info "Testing allowed_users + allowed_groups (OR logic)"
+
+    # Matching user, no matching group — should pass
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -H "X-Forwarded-User: sa:deploy-bot" \
+        -H "X-Forwarded-Groups: dev-team" \
+        -d '{"name":"test"}' \
+        "$BASE_URL/tasks/user-or-group")
+
+    if [ "$HTTP_CODE" = "202" ]; then
+        pass "user-or-group: matching user (no group match) returns 202"
+    else
+        fail "user-or-group: matching user (no group match) returns 202" "202" "$HTTP_CODE"
+    fi
+
+    # Wrong user, matching group — should pass
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -H "X-Forwarded-User: sa:other-bot" \
+        -H "X-Forwarded-Groups: ops-team" \
+        -d '{"name":"test"}' \
+        "$BASE_URL/tasks/user-or-group")
+
+    if [ "$HTTP_CODE" = "202" ]; then
+        pass "user-or-group: matching group (no user match) returns 202"
+    else
+        fail "user-or-group: matching group (no user match) returns 202" "202" "$HTTP_CODE"
+    fi
+
+    # Neither user nor group match — should be rejected
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -H "X-Forwarded-User: sa:other-bot" \
+        -H "X-Forwarded-Groups: dev-team" \
+        -d '{"name":"test"}' \
+        "$BASE_URL/tasks/user-or-group")
+
+    if [ "$HTTP_CODE" = "403" ]; then
+        pass "user-or-group: no match returns 403"
+    else
+        fail "user-or-group: no match returns 403" "403" "$HTTP_CODE"
+    fi
+}
+
+# Test: GET /tasks includes allowed_users in listing
+test_list_tasks_allowed_users() {
+    info "Testing GET /tasks includes allowed_users"
+    RESP=$(curl -s "$BASE_URL/tasks")
+
+    if echo "$RESP" | grep -q '"allowed_users"'; then
+        pass "GET /tasks includes allowed_users field"
+    else
+        fail "GET /tasks includes allowed_users field" "allowed_users in response" "$RESP"
+    fi
+}
+
 # Main
 echo "========================================" >&2
 echo "aqsh Integration Tests" >&2
@@ -485,6 +587,12 @@ test_submit_task_invalid_pattern
 test_submit_task_invalid_enum
 test_submit_task_unknown_field
 test_get_task_not_found
+
+echo "" >&2
+echo "--- Authorization Tests ---" >&2
+test_allowed_users
+test_allowed_users_or_groups
+test_list_tasks_allowed_users
 
 echo "" >&2
 echo "--- Task Execution Tests ---" >&2


### PR DESCRIPTION
## Summary

- Add `allowed_users` field to task config, matched against `X-Forwarded-User` identity header
- OR-combined with existing `allowed_groups` — authorized if either matches
- Enables restricting tasks to specific Kubernetes ServiceAccounts (whose identity is a username, not a group)

Fixes #4

## Changes

- `internal/tasks/tasks.go` — `AllowedUsers` field on `TaskDef` and `ResolvedTask`
- `internal/api/api.go` — Authorization check OR-combines user and group match; `GET /tasks` exposes `allowed_users`
- `tasks.yaml` — Two test tasks (`user-restricted`, `user-or-group`)
- `test/integration_test.sh` — 7 new e2e authorization tests (46 total, was 39)
- Unit tests for `isAllowedUser()`, `TestHandleSubmitTaskUserAuthorization` (6 sub-tests), `TestIsAllowedUser` (5 sub-tests), resolve tests
- Updated `docs/api.md` and `README.md`

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] E2e tests pass (46/46 via `docker compose` + `integration_test.sh`)
- [x] Verified by peer (`db-runbooks`) against original reproduction from issue #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user-based task authorization: tasks may restrict execution by exact user identity or by group membership (OR logic). Task listings now expose allowed_users; tasks are open when neither list is set.

* **Documentation**
  * Updated docs and API docs to describe combined user-and-group rules, OR matching, updated 403 semantics, and a trust-boundary note about forwarded headers.

* **Tests**
  * Added unit and integration tests covering user-only and user-or-group authorization and task listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->