### PR TITLE
ci: use github.repository for image path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
     branches: [main]
 
 env:
-  IMAGE: ghcr.io/rophy/aqsh
+  IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Replace hardcoded `ghcr.io/rophy/aqsh` with `ghcr.io/${{ github.repository }}`
- Fixes publish failure after repo transfer to null-ptr-exception org

## Test plan

- [ ] Merge and tag to verify publish pushes to `ghcr.io/null-ptr-exception/aqsh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to dynamically generate container image identifiers based on repository settings rather than using static values, improving workflow flexibility and portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->