### PR TITLE
ci: remove build attestation step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,6 @@ jobs:
       contents: write
       packages: write
       id-token: write
-      attestations: write
     steps:
       - uses: actions/checkout@v4
 
@@ -67,12 +66,6 @@ jobs:
           build-args: VERSION=${{ github.ref_name }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - uses: actions/attest-build-provenance@v2
-        with:
-          subject-name: ${{ env.IMAGE }}
-          subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
 
       - env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `actions/attest-build-provenance` step and `attestations: write` permission
- Not supported on the current org plan for private repos, was blocking the publish job

## Test plan

- [ ] Merge, re-tag 0.4.0, verify publish completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration. Build provenance attestations are no longer generated during the publish flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->