### PR TITLE
feat: input-level RBAC via values_url

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,7 @@ on:
     tags: ["*"]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   IMAGE: ghcr.io/${{ github.repository }}
@@ -22,6 +23,18 @@ jobs:
 
       - run: go test -v ./...
 
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: docker compose --profile dev up --build -d
+
+      - run: docker compose --profile dev run --rm dev ./test/integration_test.sh
+
+      - if: always()
+        run: docker compose --profile dev down
+
   build:
     runs-on: ubuntu-latest
     steps:
@@ -35,7 +48,7 @@ jobs:
 
   publish:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [test, build]
+    needs: [test, integration, build]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,6 +13,12 @@ services:
     depends_on:
       - redis
 
+  mock-values:
+    image: python:3-alpine
+    command: python /scripts/server.py
+    volumes:
+      - ./test/mock-values-server:/scripts:ro
+
   dev:
     build:
       context: .
@@ -20,6 +26,7 @@ services:
     environment:
       AQSH_REDIS_ADDR: redis:6379
       AQSH_URL: http://aqsh:8080
+      MOCK_VALUES_URL: http://mock-values:8090
       DEV_CONTAINER: "true"
     volumes:
       - .:/app
@@ -27,5 +34,6 @@ services:
     depends_on:
       - redis
       - aqsh
+      - mock-values
     profiles:
       - dev

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,40 +4,17 @@
 
 ### GET /tasks - List All Task Definitions
 
+Returns task names and descriptions. Use `GET /tasks/{name}` for full details.
+
 **Response (200 OK):**
 ```json
 {
   "tasks": {
     "deploy": {
-      "description": "Deploy application to environment",
-      "timeout": "10m",
-      "max_retry": 2,
-      "queue": "default",
-      "allowed_groups": ["deploy-team", "platform-team"],
-      "input": [
-        {
-          "name": "version",
-          "env": "VERSION",
-          "required": true,
-          "type": "string",
-          "pattern": "^v?\\d+\\.\\d+\\.\\d+$",
-          "description": "Semantic version to deploy"
-        },
-        {
-          "name": "environment",
-          "env": "ENVIRONMENT",
-          "required": true,
-          "type": "string",
-          "enum": ["dev", "staging", "prod"]
-        },
-        {
-          "name": "dry_run",
-          "env": "DRY_RUN",
-          "required": false,
-          "type": "bool",
-          "default": "false"
-        }
-      ]
+      "description": "Deploy application to environment"
+    },
+    "backup": {
+      "description": "Backup database to S3"
     }
   }
 }
@@ -45,14 +22,14 @@
 
 ### GET /tasks/{name} - Get Task Definition
 
-Returns a single task definition by name. Inputs with `values_url` include `"values_url": true` to indicate dynamic values.
+Returns full task definition including inputs. When identity headers are provided, inputs with `values_url` resolve the remote URL and include the allowed values for that user.
 
-**Response (200 OK):**
+**Response without identity (200 OK):**
 ```json
 {
-  "description": "Deploy application to environment",
+  "description": "Upgrade a database instance",
   "timeout": "10m",
-  "max_retry": 2,
+  "max_retry": 0,
   "queue": "default",
   "input": [
     {
@@ -61,6 +38,29 @@ Returns a single task definition by name. Inputs with `values_url` include `"val
       "required": true,
       "type": "string",
       "values_url": true
+    }
+  ]
+}
+```
+
+**Response with identity header (200 OK):**
+```json
+{
+  "description": "Upgrade a database instance",
+  "timeout": "10m",
+  "max_retry": 0,
+  "queue": "default",
+  "input": [
+    {
+      "name": "instance",
+      "env": "DB_INSTANCE",
+      "required": true,
+      "type": "string",
+      "values_url": true,
+      "values": [
+        {"name": "Production DB 001", "value": "prod-db-001"},
+        {"name": "Production DB 002", "value": "prod-db-002"}
+      ]
     }
   ]
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -67,6 +67,7 @@ Returns full task definition including inputs. When identity headers are provide
 ```
 
 **Errors:**
+
 | Status | Reason |
 |--------|--------|
 | 404 | Unknown task |
@@ -105,6 +106,7 @@ Inputs with `values_url` perform additional per-parameter authorization: the rem
 ```
 
 **Errors:**
+
 | Status | Reason |
 |--------|--------|
 | 401 | Missing identity header (when `AQSH_REQUIRE_IDENTITY=true`) |
@@ -140,6 +142,7 @@ Inputs with `values_url` perform additional per-parameter authorization: the rem
 ```
 
 **Status Values:**
+
 | Status | Description |
 |--------|-------------|
 | `pending` | Queued, waiting for worker |
@@ -172,6 +175,7 @@ data: Deployment complete.
 - Connection closed when execution completes or fails
 
 **Query Parameters:**
+
 | Param | Description | Default |
 |-------|-------------|---------|
 | `follow` | Keep connection open for running executions | `true` |

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,105 +1,8 @@
 # API Reference
 
-## POST /tasks/{name} - Submit Task
+## Task Definitions
 
-**Request:**
-```http
-POST /tasks/deploy
-Content-Type: application/json
-X-Forwarded-User: alice@example.com
-
-{
-  "version": "1.2.3",
-  "environment": "prod"
-}
-```
-
-**Identity Header:**
-
-The identity header (default `X-Forwarded-User`, configurable via `AQSH_IDENTITY_HEADER`) identifies who submitted the task. When `AQSH_REQUIRE_IDENTITY=true`, requests without this header are rejected with 401.
-
-**Authorization:**
-
-Tasks can restrict access using `allowed_users` and/or `allowed_groups` in their config. If either matches, the request is authorized (OR logic). `allowed_users` matches against the identity header; `allowed_groups` matches against the groups header (comma-separated). If neither is configured, the task is open to all.
-
-**Response (202 Accepted):**
-```json
-{
-  "id": "task_01HQXK5V7Z8Y9ABCDEF",
-  "queue": "default",
-  "status": "pending"
-}
-```
-
-**Errors:**
-| Status | Reason |
-|--------|--------|
-| 401 | Missing identity header (when `AQSH_REQUIRE_IDENTITY=true`) |
-| 403 | Not authorized for this task (user/group check failed) |
-| 400 | Validation error (missing field, invalid pattern, etc.) |
-| 404 | Unknown task |
-| 503 | Redis unavailable |
-
-## GET /tasks/{id} - Get Task Status
-
-**Response (200 OK):**
-```json
-{
-  "id": "task_01HQXK5V7Z8Y9ABCDEF",
-  "queue": "default",
-  "status": "completed",
-  "identity": "alice@example.com",
-  "groups": "deploy-team,platform-team",
-  "created_at": "2025-12-28T10:00:00Z",
-  "started_at": "2025-12-28T10:00:01Z",
-  "completed_at": "2025-12-28T10:00:15Z",
-  "retried": 0,
-  "max_retry": 3,
-  "result": {
-    "exit_code": 0,
-    "data": "{\"status\":\"deployed\",\"version\":\"1.2.3\",\"environment\":\"prod\"}"
-  }
-}
-```
-
-**Status Values:**
-| Status | Description |
-|--------|-------------|
-| `pending` | Queued, waiting for worker |
-| `running` | Currently executing |
-| `completed` | Finished successfully (exit code 0) |
-| `failed` | Failed after all retries |
-| `retrying` | Failed, scheduled for retry |
-
-## GET /tasks/{id}/logs - Stream Logs
-
-**Response (200 OK, SSE):**
-```http
-Content-Type: text/event-stream
-Cache-Control: no-cache
-Connection: keep-alive
-
-data: Starting deployment...
-
-data: Pulling image v1.2.3...
-
-data: Scaling replicas to 3...
-
-data: Deployment complete.
-```
-
-**Behavior:**
-- For running tasks: streams logs in real-time
-- For completed tasks: streams stored logs
-- For pending tasks: waits for task to start, then streams
-- Connection closed when task completes or fails
-
-**Query Parameters:**
-| Param | Description | Default |
-|-------|-------------|---------|
-| `follow` | Keep connection open for running tasks | `true` |
-
-## GET /tasks - List Task Types
+### GET /tasks - List All Task Definitions
 
 **Response (200 OK):**
 ```json
@@ -135,27 +38,147 @@ data: Deployment complete.
           "default": "false"
         }
       ]
-    },
-    "backup": {
-      "description": "Backup database to S3",
-      "timeout": "30m",
-      "max_retry": 1,
-      "queue": "long-running",
-      "input": [
-        {
-          "name": "database",
-          "env": "DATABASE",
-          "required": true,
-          "type": "string",
-          "pattern": "^[a-z][a-z0-9_]{2,30}$"
-        }
-      ]
     }
   }
 }
 ```
 
-## GET /health - Health Check
+### GET /tasks/{name} - Get Task Definition
+
+Returns a single task definition by name. Inputs with `values_url` include `"values_url": true` to indicate dynamic values.
+
+**Response (200 OK):**
+```json
+{
+  "description": "Deploy application to environment",
+  "timeout": "10m",
+  "max_retry": 2,
+  "queue": "default",
+  "input": [
+    {
+      "name": "instance",
+      "env": "DB_INSTANCE",
+      "required": true,
+      "type": "string",
+      "values_url": true
+    }
+  ]
+}
+```
+
+**Errors:**
+| Status | Reason |
+|--------|--------|
+| 404 | Unknown task |
+
+### POST /tasks/{name} - Submit Task Execution
+
+**Request:**
+```http
+POST /tasks/deploy
+Content-Type: application/json
+X-Forwarded-User: alice@example.com
+
+{
+  "version": "1.2.3",
+  "environment": "prod"
+}
+```
+
+**Identity Header:**
+
+The identity header (default `X-Forwarded-User`, configurable via `AQSH_IDENTITY_HEADER`) identifies who submitted the task. When `AQSH_REQUIRE_IDENTITY=true`, requests without this header are rejected with 401.
+
+**Authorization:**
+
+Tasks can restrict access using `allowed_users` and/or `allowed_groups` in their config. If either matches, the request is authorized (OR logic). `allowed_users` matches against the identity header; `allowed_groups` matches against the groups header (comma-separated). If neither is configured, the task is open to all.
+
+Inputs with `values_url` perform additional per-parameter authorization: the remote URL is fetched with user context, and the submitted value must be in the returned list.
+
+**Response (202 Accepted):**
+```json
+{
+  "id": "task_01HQXK5V7Z8Y9ABCDEF",
+  "queue": "default",
+  "status": "pending"
+}
+```
+
+**Errors:**
+| Status | Reason |
+|--------|--------|
+| 401 | Missing identity header (when `AQSH_REQUIRE_IDENTITY=true`) |
+| 403 | Not authorized for this task (user/group check failed), or submitted value not in allowed values from `values_url` |
+| 400 | Validation error (missing field, invalid pattern, etc.) |
+| 404 | Unknown task |
+| 502 | Remote values URL returned error |
+| 504 | Remote values URL timed out |
+| 503 | Redis unavailable |
+
+## Executions
+
+### GET /executions/{id} - Get Execution Status
+
+**Response (200 OK):**
+```json
+{
+  "id": "task_01HQXK5V7Z8Y9ABCDEF",
+  "queue": "default",
+  "status": "completed",
+  "identity": "alice@example.com",
+  "groups": "deploy-team,platform-team",
+  "created_at": "2025-12-28T10:00:00Z",
+  "started_at": "2025-12-28T10:00:01Z",
+  "completed_at": "2025-12-28T10:00:15Z",
+  "retried": 0,
+  "max_retry": 3,
+  "result": {
+    "exit_code": 0,
+    "data": "{\"status\":\"deployed\",\"version\":\"1.2.3\",\"environment\":\"prod\"}"
+  }
+}
+```
+
+**Status Values:**
+| Status | Description |
+|--------|-------------|
+| `pending` | Queued, waiting for worker |
+| `running` | Currently executing |
+| `completed` | Finished successfully (exit code 0) |
+| `failed` | Failed after all retries |
+| `retrying` | Failed, scheduled for retry |
+
+### GET /executions/{id}/logs - Stream Execution Logs
+
+**Response (200 OK, SSE):**
+```http
+Content-Type: text/event-stream
+Cache-Control: no-cache
+Connection: keep-alive
+
+data: Starting deployment...
+
+data: Pulling image v1.2.3...
+
+data: Scaling replicas to 3...
+
+data: Deployment complete.
+```
+
+**Behavior:**
+- For running executions: streams logs in real-time
+- For completed executions: streams stored logs
+- For pending executions: waits for execution to start, then streams
+- Connection closed when execution completes or fails
+
+**Query Parameters:**
+| Param | Description | Default |
+|-------|-------------|---------|
+| `follow` | Keep connection open for running executions | `true` |
+
+## System
+
+### GET /health - Health Check
 
 **Response (200 OK):**
 ```json
@@ -167,6 +190,6 @@ data: Deployment complete.
 }
 ```
 
-## GET /metrics - Prometheus Metrics
+### GET /metrics - Prometheus Metrics
 
 Returns Prometheus-formatted metrics. See [Observability](../README.md#observability) for details.

--- a/docs/input-rbac-design.md
+++ b/docs/input-rbac-design.md
@@ -83,10 +83,10 @@ On `POST /tasks/{name}`:
    d. If the submitted value is not in the set, reject with **403 Forbidden**.
 3. Standard input validation (type, pattern, enum) runs after.
 
-On `GET /tasks`:
+On `GET /tasks/{name}`:
 
 - If a request includes identity/groups headers, inputs with `values_url` include the fetched values in the response (so clients can render dropdowns).
-- If no identity is provided, `values_url` inputs omit the values list and just indicate `"values_url": true` to signal dynamic values.
+- If no identity or groups are provided, `values_url` inputs omit the values list and just indicate `"values_url": true` to signal dynamic values.
 
 ### Error Handling
 

--- a/docs/input-rbac-design.md
+++ b/docs/input-rbac-design.md
@@ -1,0 +1,160 @@
+# Input-Level RBAC via Remote Values URL
+
+## Problem
+
+aqsh supports per-task authorization via `allowed_users` and `allowed_groups`, but this is too coarse for many real-world scenarios. Consider a "upgrade DB" task where a user selects from 1000 database instances — creating a separate task definition per instance doesn't scale, and static enum lists can't enforce per-user access control.
+
+We need a way to:
+1. Dynamically populate allowed values for an input parameter from an external source.
+2. Filter those values based on who is submitting the task.
+3. Enforce that submitted values are within the user's authorized set.
+
+## Prior Art: Rundeck Remote URL
+
+Rundeck's [Remote URL for option values](https://docs.rundeck.com/docs/manual/jobs/job-options.html#text-option-type) provides a good model:
+
+- A job option can specify a URL that returns allowed values.
+- The URL receives context variables (user, other option values) via template substitution.
+- The remote service decides which values to return per user — authorization is delegated.
+- Response format: `[{"name": "Display Label", "value": "actual_value"}]`
+
+## Design
+
+### Configuration
+
+Add `values_url` to input definitions in `tasks.yaml`:
+
+```yaml
+tasks:
+  upgrade-db:
+    script: upgrade-db.sh
+    description: "Upgrade a database instance"
+    allowed_groups: [dba-team]
+    input:
+      - name: instance
+        env: DB_INSTANCE
+        required: true
+        type: string
+        values_url: "http://authz.internal/db-instances?user=${identity}&groups=${groups}"
+        description: "Target database instance"
+```
+
+### Template Variables
+
+The following variables are substituted into `values_url` before the request is made:
+
+| Variable | Source | Example |
+|----------|--------|---------|
+| `${identity}` | Identity header value | `alice@example.com` |
+| `${groups}` | Groups header value (comma-separated) | `dba-team,platform` |
+| `${task}` | Task name | `upgrade-db` |
+
+### Remote URL Response Format
+
+The remote service returns a JSON array. Three formats are accepted (following Rundeck's convention):
+
+**Simple list:**
+```json
+["prod-db-001", "prod-db-002", "staging-db-001"]
+```
+
+**Name-value pairs (ordered, with display labels):**
+```json
+[
+  {"name": "Production DB 001", "value": "prod-db-001"},
+  {"name": "Production DB 002", "value": "prod-db-002"}
+]
+```
+
+**Key-value object (unordered):**
+```json
+{"Production DB 001": "prod-db-001", "Production DB 002": "prod-db-002"}
+```
+
+### Validation Flow
+
+On `POST /tasks/{name}`:
+
+1. Task-level authorization runs first (`allowed_users` / `allowed_groups`).
+2. For each input with `values_url`:
+   a. Substitute template variables into the URL.
+   b. Fetch the URL (with timeout).
+   c. Parse the response into a set of allowed values.
+   d. If the submitted value is not in the set, reject with **403 Forbidden**.
+3. Standard input validation (type, pattern, enum) runs after.
+
+On `GET /tasks`:
+
+- If a request includes identity/groups headers, inputs with `values_url` include the fetched values in the response (so clients can render dropdowns).
+- If no identity is provided, `values_url` inputs omit the values list and just indicate `"values_url": true` to signal dynamic values.
+
+### Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| Remote URL returns non-200 | Reject task submission with 502 |
+| Remote URL times out | Reject task submission with 504 |
+| Remote URL returns invalid JSON | Reject task submission with 502 |
+| Remote URL returns empty list | Submitted value will always fail validation (403) |
+| `values_url` and `enum` both set | Config error at load time |
+
+### Interaction with Existing Validation
+
+- `values_url` and `enum` are mutually exclusive (both define allowed values; one static, one dynamic).
+- `pattern`, `min`, `max`, `type` still apply after `values_url` validation.
+- `required` and `default` work as before.
+
+## Implementation Plan
+
+### Phase 1: Core `values_url` validation on submit
+
+Add `values_url` field to `Input` struct. On task submission, fetch the URL with substituted variables, parse the response, and validate the submitted value against the returned set. Reject with 403 if not in set, 502/504 on fetch errors.
+
+Scope:
+- `internal/tasks/tasks.go` — add `ValuesURL` field, mutual exclusion check with `enum`
+- `internal/api/api.go` — fetch + validate logic in submit handler
+- New `internal/api/values.go` — URL template substitution, HTTP fetch, response parsing
+- Unit tests for URL substitution, response parsing, mutual exclusion
+- Integration test with a mock HTTP server
+
+### Phase 2: Expose values in `GET /tasks`
+
+When `GET /tasks` is called with identity headers, fetch `values_url` for each input and include the allowed values in the response. This enables clients to render dynamic dropdowns.
+
+Scope:
+- `internal/api/api.go` — update `handleListTasks` to optionally fetch values
+- Consider parallel fetching if multiple inputs have `values_url`
+
+### Phase 3: Caching
+
+Add a short-TTL in-memory cache (keyed by URL after substitution) to avoid hitting the remote service on every request. Configurable TTL via `values_cache` on the input or a global default.
+
+```yaml
+input:
+  - name: instance
+    values_url: "http://authz.internal/db-instances?user=${identity}"
+    values_cache: 30s
+```
+
+Scope:
+- Cache implementation (simple map with expiry, or `sync.Map` + TTL)
+- Cache key: fully-substituted URL
+- Default TTL: 0 (no cache), configurable per-input
+
+### Phase 4: Cascading parameters
+
+Allow one input's `values_url` to reference another input's submitted value, enabling dependent dropdowns (e.g., select region first, then instance list filters by region).
+
+```yaml
+input:
+  - name: region
+    env: REGION
+    type: string
+    enum: [us-east-1, eu-west-1]
+  - name: instance
+    env: DB_INSTANCE
+    type: string
+    values_url: "http://authz.internal/instances?region=${input.region}&user=${identity}"
+```
+
+This requires defining input evaluation order (top-to-bottom) and validating inputs sequentially when cascading is used.

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -23,13 +23,14 @@ import (
 )
 
 type Server struct {
-	cfg       *config.Config
-	tasks     *tasks.TasksConfig
-	client    *asynq.Client
-	inspector *asynq.Inspector
-	logStream *logs.LogStreamer
-	rdb       redis.UniversalClient
-	version   string
+	cfg        *config.Config
+	tasks      *tasks.TasksConfig
+	client     *asynq.Client
+	inspector  *asynq.Inspector
+	logStream  *logs.LogStreamer
+	rdb        redis.UniversalClient
+	version    string
+	valCache   *valuesCache
 }
 
 func New(cfg *config.Config, tasksConfig *tasks.TasksConfig, rdb redis.UniversalClient, asynqOpt asynq.RedisConnOpt, version string) *Server {
@@ -41,6 +42,7 @@ func New(cfg *config.Config, tasksConfig *tasks.TasksConfig, rdb redis.Universal
 		logStream: logs.NewLogStreamer(rdb, cfg.LogRetention),
 		rdb:       rdb,
 		version:   version,
+		valCache:  newValuesCache(),
 	}
 }
 
@@ -179,7 +181,7 @@ func (s *Server) handleSubmitTask(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		fetchURL := substituteURL(input.ValuesURL, identity, groups, taskName)
-		allowed, err := fetchAllowedValues(r.Context(), fetchURL)
+		allowed, err := s.fetchOrCachedValues(r.Context(), fetchURL, input.ValuesCache)
 		if err != nil {
 			if strings.Contains(err.Error(), "timeout") {
 				s.jsonError(w, http.StatusGatewayTimeout, fmt.Sprintf("timeout fetching allowed values for %q", input.Name))
@@ -255,7 +257,7 @@ func (s *Server) handleGetTaskDef(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			fetchURL := substituteURL(input.ValuesURL, identity, groups, taskName)
-			allowed, err := fetchAllowedValues(r.Context(), fetchURL)
+			allowed, err := s.fetchOrCachedValues(r.Context(), fetchURL, input.ValuesCache)
 			if err != nil {
 				continue
 			}
@@ -455,6 +457,26 @@ func (s *Server) jsonResponse(w http.ResponseWriter, status int, data any) {
 
 func (s *Server) jsonError(w http.ResponseWriter, status int, message string) {
 	s.jsonResponse(w, status, map[string]string{"error": message})
+}
+
+func (s *Server) fetchOrCachedValues(ctx context.Context, url string, cacheDuration string) ([]AllowedValue, error) {
+	ttl, _ := time.ParseDuration(cacheDuration)
+	if ttl > 0 && s.valCache != nil {
+		if cached, ok := s.valCache.get(url); ok {
+			return cached, nil
+		}
+	}
+
+	values, err := fetchAllowedValues(ctx, url)
+	if err != nil {
+		return nil, err
+	}
+
+	if ttl > 0 && s.valCache != nil {
+		s.valCache.set(url, values, ttl)
+	}
+
+	return values, nil
 }
 
 func findInput(inputs []tasks.Input, name string) *tasks.Input {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -239,7 +239,35 @@ func (s *Server) handleGetTaskDef(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.jsonResponse(w, http.StatusOK, serializeTaskDef(taskDef))
+	result := serializeTaskDef(taskDef)
+
+	identity := r.Header.Get(s.cfg.IdentityHeader)
+	groups := r.Header.Get(s.cfg.GroupsHeader)
+	if identity != "" {
+		inputs := result["input"].([]map[string]any)
+		for _, m := range inputs {
+			valuesURL, ok := m["values_url"]
+			if !ok || valuesURL != true {
+				continue
+			}
+			input := findInput(taskDef.Input, m["name"].(string))
+			if input == nil {
+				continue
+			}
+			fetchURL := substituteURL(input.ValuesURL, identity, groups, taskName)
+			allowed, err := fetchAllowedValues(r.Context(), fetchURL)
+			if err != nil {
+				continue
+			}
+			values := make([]map[string]string, len(allowed))
+			for i, av := range allowed {
+				values[i] = map[string]string{"name": av.Name, "value": av.Value}
+			}
+			m["values"] = values
+		}
+	}
+
+	s.jsonResponse(w, http.StatusOK, result)
 }
 
 func (s *Server) handleGetExecution(w http.ResponseWriter, r *http.Request) {
@@ -376,7 +404,9 @@ func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 	result := make(map[string]any)
 	for name := range s.tasks.Tasks {
 		taskDef, _ := s.tasks.Resolve(name)
-		result[name] = serializeTaskDef(taskDef)
+		result[name] = map[string]any{
+			"description": taskDef.Description,
+		}
 	}
 
 	s.jsonResponse(w, http.StatusOK, map[string]any{"tasks": result})
@@ -425,6 +455,15 @@ func (s *Server) jsonResponse(w http.ResponseWriter, status int, data any) {
 
 func (s *Server) jsonError(w http.ResponseWriter, status int, message string) {
 	s.jsonResponse(w, status, map[string]string{"error": message})
+}
+
+func findInput(inputs []tasks.Input, name string) *tasks.Input {
+	for i := range inputs {
+		if inputs[i].Name == name {
+			return &inputs[i]
+		}
+	}
+	return nil
 }
 
 func splitGroups(header string) []string {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -187,6 +187,10 @@ func (s *Server) handleSubmitTask(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		fetchURL := substituteURL(input.ValuesURL, identity, groups, taskName, inputValues)
+		if strings.Contains(fetchURL, "${input.") {
+			s.jsonError(w, http.StatusBadRequest, fmt.Sprintf("field %q depends on an unresolved input parameter", input.Name))
+			return
+		}
 		allowed, err := s.fetchOrCachedValues(r.Context(), fetchURL, input.ValuesCache)
 		if err != nil {
 			if strings.Contains(err.Error(), "timeout") {
@@ -251,7 +255,7 @@ func (s *Server) handleGetTaskDef(w http.ResponseWriter, r *http.Request) {
 
 	identity := r.Header.Get(s.cfg.IdentityHeader)
 	groups := r.Header.Get(s.cfg.GroupsHeader)
-	if identity != "" {
+	if identity != "" || groups != "" {
 		inputs := result["input"].([]map[string]any)
 		for _, m := range inputs {
 			valuesURL, ok := m["values_url"]
@@ -268,6 +272,8 @@ func (s *Server) handleGetTaskDef(w http.ResponseWriter, r *http.Request) {
 			}
 			allowed, err := s.fetchOrCachedValues(r.Context(), fetchURL, input.ValuesCache)
 			if err != nil {
+				slog.Warn("failed to resolve values_url", "task", taskName, "input", input.Name, "error", err)
+				m["values_error"] = err.Error()
 				continue
 			}
 			values := make([]map[string]string, len(allowed))

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -166,8 +166,14 @@ func (s *Server) handleSubmitTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate values_url inputs against remote allowed values
+	// Validate values_url inputs against remote allowed values (in order, for cascading)
+	inputValues := make(map[string]string)
 	for _, input := range taskDef.Input {
+		if v, ok := payload[input.Name]; ok && v != nil {
+			if s, ok := v.(string); ok {
+				inputValues[input.Name] = s
+			}
+		}
 		if input.ValuesURL == "" {
 			continue
 		}
@@ -180,7 +186,7 @@ func (s *Server) handleSubmitTask(w http.ResponseWriter, r *http.Request) {
 			s.jsonError(w, http.StatusBadRequest, fmt.Sprintf("field %q must be a string for values_url validation", input.Name))
 			return
 		}
-		fetchURL := substituteURL(input.ValuesURL, identity, groups, taskName)
+		fetchURL := substituteURL(input.ValuesURL, identity, groups, taskName, inputValues)
 		allowed, err := s.fetchOrCachedValues(r.Context(), fetchURL, input.ValuesCache)
 		if err != nil {
 			if strings.Contains(err.Error(), "timeout") {
@@ -256,7 +262,10 @@ func (s *Server) handleGetTaskDef(w http.ResponseWriter, r *http.Request) {
 			if input == nil {
 				continue
 			}
-			fetchURL := substituteURL(input.ValuesURL, identity, groups, taskName)
+			fetchURL := substituteURL(input.ValuesURL, identity, groups, taskName, nil)
+			if strings.Contains(fetchURL, "${input.") {
+				continue
+			}
 			allowed, err := s.fetchOrCachedValues(r.Context(), fetchURL, input.ValuesCache)
 			if err != nil {
 				continue

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -103,9 +103,10 @@ func (s *Server) Run(ctx context.Context) error {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("POST /tasks/{name}", s.handleSubmitTask)
-	mux.HandleFunc("GET /tasks/{id}", s.handleGetTask)
-	mux.HandleFunc("GET /tasks/{id}/logs", s.handleGetLogs)
+	mux.HandleFunc("GET /tasks/{name}", s.handleGetTaskDef)
 	mux.HandleFunc("GET /tasks", s.handleListTasks)
+	mux.HandleFunc("GET /executions/{id}", s.handleGetExecution)
+	mux.HandleFunc("GET /executions/{id}/logs", s.handleGetLogs)
 	mux.HandleFunc("GET /health", s.handleHealth)
 	mux.Handle("GET /metrics", promhttp.Handler())
 
@@ -229,7 +230,19 @@ func (s *Server) handleSubmitTask(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func (s *Server) handleGetTask(w http.ResponseWriter, r *http.Request) {
+func (s *Server) handleGetTaskDef(w http.ResponseWriter, r *http.Request) {
+	taskName := r.PathValue("name")
+
+	taskDef, err := s.tasks.Resolve(taskName)
+	if err != nil {
+		s.jsonError(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	s.jsonResponse(w, http.StatusOK, serializeTaskDef(taskDef))
+}
+
+func (s *Server) handleGetExecution(w http.ResponseWriter, r *http.Request) {
 	taskID := r.PathValue("id")
 
 	// Try all queues the worker is configured to process
@@ -363,52 +376,7 @@ func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 	result := make(map[string]any)
 	for name := range s.tasks.Tasks {
 		taskDef, _ := s.tasks.Resolve(name)
-		inputs := make([]map[string]any, 0, len(taskDef.Input))
-		for _, input := range taskDef.Input {
-			m := map[string]any{
-				"name":     input.Name,
-				"env":      input.Env,
-				"required": input.Required,
-				"type":     input.Type,
-			}
-			if input.Pattern != "" {
-				m["pattern"] = input.Pattern
-			}
-			if len(input.Enum) > 0 {
-				m["enum"] = input.Enum
-			}
-			if input.Min != nil {
-				m["min"] = *input.Min
-			}
-			if input.Max != nil {
-				m["max"] = *input.Max
-			}
-			if input.Default != "" {
-				m["default"] = input.Default
-			}
-			if input.Description != "" {
-				m["description"] = input.Description
-			}
-			if input.ValuesURL != "" {
-				m["values_url"] = true
-			}
-			inputs = append(inputs, m)
-		}
-
-		taskInfo := map[string]any{
-			"description": taskDef.Description,
-			"timeout":     taskDef.Timeout.String(),
-			"max_retry":   taskDef.MaxRetry,
-			"queue":       taskDef.Queue,
-			"input":       inputs,
-		}
-		if len(taskDef.AllowedGroups) > 0 {
-			taskInfo["allowed_groups"] = taskDef.AllowedGroups
-		}
-		if len(taskDef.AllowedUsers) > 0 {
-			taskInfo["allowed_users"] = taskDef.AllowedUsers
-		}
-		result[name] = taskInfo
+		result[name] = serializeTaskDef(taskDef)
 	}
 
 	s.jsonResponse(w, http.StatusOK, map[string]any{"tasks": result})
@@ -494,6 +462,55 @@ func hasAnyGroup(userGroups, allowedGroups []string) bool {
 		}
 	}
 	return false
+}
+
+func serializeTaskDef(taskDef *tasks.ResolvedTask) map[string]any {
+	inputs := make([]map[string]any, 0, len(taskDef.Input))
+	for _, input := range taskDef.Input {
+		m := map[string]any{
+			"name":     input.Name,
+			"env":      input.Env,
+			"required": input.Required,
+			"type":     input.Type,
+		}
+		if input.Pattern != "" {
+			m["pattern"] = input.Pattern
+		}
+		if len(input.Enum) > 0 {
+			m["enum"] = input.Enum
+		}
+		if input.Min != nil {
+			m["min"] = *input.Min
+		}
+		if input.Max != nil {
+			m["max"] = *input.Max
+		}
+		if input.Default != "" {
+			m["default"] = input.Default
+		}
+		if input.Description != "" {
+			m["description"] = input.Description
+		}
+		if input.ValuesURL != "" {
+			m["values_url"] = true
+		}
+		inputs = append(inputs, m)
+	}
+
+	info := map[string]any{
+		"description": taskDef.Description,
+		"timeout":     taskDef.Timeout.String(),
+		"max_retry":   taskDef.MaxRetry,
+		"queue":       taskDef.Queue,
+		"input":       inputs,
+	}
+	if len(taskDef.AllowedGroups) > 0 {
+		info["allowed_groups"] = taskDef.AllowedGroups
+	}
+	if len(taskDef.AllowedUsers) > 0 {
+		info["allowed_users"] = taskDef.AllowedUsers
+	}
+	return info
 }
 
 func stateToStatus(state asynq.TaskState) string {

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -163,6 +163,36 @@ func (s *Server) handleSubmitTask(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Validate values_url inputs against remote allowed values
+	for _, input := range taskDef.Input {
+		if input.ValuesURL == "" {
+			continue
+		}
+		submitted, ok := payload[input.Name]
+		if !ok || submitted == nil {
+			continue
+		}
+		submittedStr, ok := submitted.(string)
+		if !ok {
+			s.jsonError(w, http.StatusBadRequest, fmt.Sprintf("field %q must be a string for values_url validation", input.Name))
+			return
+		}
+		fetchURL := substituteURL(input.ValuesURL, identity, groups, taskName)
+		allowed, err := fetchAllowedValues(r.Context(), fetchURL)
+		if err != nil {
+			if strings.Contains(err.Error(), "timeout") {
+				s.jsonError(w, http.StatusGatewayTimeout, fmt.Sprintf("timeout fetching allowed values for %q", input.Name))
+			} else {
+				s.jsonError(w, http.StatusBadGateway, fmt.Sprintf("error fetching allowed values for %q: %s", input.Name, err.Error()))
+			}
+			return
+		}
+		if !isValueAllowed(submittedStr, allowed) {
+			s.jsonError(w, http.StatusForbidden, fmt.Sprintf("value %q is not allowed for field %q", submittedStr, input.Name))
+			return
+		}
+	}
+
 	env, err := s.tasks.ValidatePayload(taskName, payload)
 	if err != nil {
 		s.jsonError(w, http.StatusBadRequest, err.Error())
@@ -358,6 +388,9 @@ func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 			}
 			if input.Description != "" {
 				m["description"] = input.Description
+			}
+			if input.ValuesURL != "" {
+				m["values_url"] = true
 			}
 			inputs = append(inputs, m)
 		}

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -177,36 +177,15 @@ func TestHandleListTasks(t *testing.T) {
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	defer rdb.Close()
 
-	floatPtr := func(f float64) *float64 { return &f }
-	intPtr := func(i int) *int { return &i }
-
 	tasksConfig := &tasks.TasksConfig{
 		Tasks: map[string]tasks.TaskDef{
 			"deploy": {
 				Script:      "deploy.sh",
 				Description: "Deploy the application",
-				Timeout:     "5m",
-				MaxRetry:    intPtr(3),
-				Queue:       "critical",
-				Input: []tasks.Input{
-					{
-						Name:     "env",
-						Env:      "DEPLOY_ENV",
-						Type:     "string",
-						Required: true,
-						Enum:     []string{"staging", "production"},
-					},
-					{
-						Name:        "replicas",
-						Env:         "REPLICAS",
-						Type:        "int",
-						Required:    false,
-						Min:         floatPtr(1),
-						Max:         floatPtr(10),
-						Default:     "3",
-						Description: "Number of replicas",
-					},
-				},
+			},
+			"backup": {
+				Script:      "backup.sh",
+				Description: "Backup database",
 			},
 		},
 	}
@@ -236,50 +215,41 @@ func TestHandleListTasks(t *testing.T) {
 		t.Fatal("expected tasks object in response")
 	}
 
-	deployTask, ok := tasksResp["deploy"].(map[string]any)
-	if !ok {
-		t.Fatal("expected deploy task in response")
+	if len(tasksResp) != 2 {
+		t.Errorf("expected 2 tasks, got %d", len(tasksResp))
 	}
 
+	deployTask := tasksResp["deploy"].(map[string]any)
 	if deployTask["description"] != "Deploy the application" {
 		t.Errorf("expected description='Deploy the application', got %v", deployTask["description"])
 	}
-	if deployTask["queue"] != "critical" {
-		t.Errorf("expected queue='critical', got %v", deployTask["queue"])
-	}
-	if int(deployTask["max_retry"].(float64)) != 3 {
-		t.Errorf("expected max_retry=3, got %v", deployTask["max_retry"])
-	}
 
-	inputs, ok := deployTask["input"].([]any)
-	if !ok || len(inputs) != 2 {
-		t.Fatalf("expected 2 inputs, got %v", deployTask["input"])
+	if _, hasInput := deployTask["input"]; hasInput {
+		t.Error("list response should not include input details")
 	}
-
-	// Check first input (env)
-	envInput := inputs[0].(map[string]any)
-	if envInput["name"] != "env" {
-		t.Errorf("expected input name='env', got %v", envInput["name"])
-	}
-	if envInput["required"] != true {
-		t.Errorf("expected required=true, got %v", envInput["required"])
-	}
-	enum := envInput["enum"].([]any)
-	if len(enum) != 2 {
-		t.Errorf("expected 2 enum values, got %v", enum)
-	}
-
-	// Check second input (replicas)
-	replicasInput := inputs[1].(map[string]any)
-	if replicasInput["default"] != "3" {
-		t.Errorf("expected default='3', got %v", replicasInput["default"])
-	}
-	if replicasInput["description"] != "Number of replicas" {
-		t.Errorf("expected description set, got %v", replicasInput["description"])
+	if _, hasTimeout := deployTask["timeout"]; hasTimeout {
+		t.Error("list response should not include timeout")
 	}
 }
 
 func TestHandleGetTaskDef(t *testing.T) {
+	valueSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user := r.URL.Query().Get("user")
+		switch user {
+		case "alice":
+			json.NewEncoder(w).Encode([]struct {
+				Name  string `json:"name"`
+				Value string `json:"value"`
+			}{
+				{Name: "DB One", Value: "db-001"},
+				{Name: "DB Two", Value: "db-002"},
+			})
+		default:
+			json.NewEncoder(w).Encode([]string{})
+		}
+	}))
+	defer valueSrv.Close()
+
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	defer rdb.Close()
@@ -292,19 +262,22 @@ func TestHandleGetTaskDef(t *testing.T) {
 				Timeout:     "5m",
 				Input: []tasks.Input{
 					{Name: "env", Env: "ENV", Type: "string", Required: true, Enum: []string{"dev", "prod"}},
-					{Name: "instance", Env: "INSTANCE", Type: "string", ValuesURL: "http://example.com/values"},
+					{Name: "instance", Env: "INSTANCE", Type: "string", ValuesURL: valueSrv.URL + "?user=${identity}"},
 				},
 			},
 		},
 	}
 
 	s := &Server{
-		cfg:   &config.Config{},
+		cfg: &config.Config{
+			IdentityHeader: "X-Forwarded-User",
+			GroupsHeader:   "X-Forwarded-Groups",
+		},
 		tasks: tasksConfig,
 		rdb:   rdb,
 	}
 
-	t.Run("existing task", func(t *testing.T) {
+	t.Run("without identity returns values_url flag only", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "/tasks/deploy", nil)
 		req.SetPathValue("name", "deploy")
 		rec := httptest.NewRecorder()
@@ -318,18 +291,45 @@ func TestHandleGetTaskDef(t *testing.T) {
 		var resp map[string]any
 		json.Unmarshal(rec.Body.Bytes(), &resp)
 
-		if resp["description"] != "Deploy the app" {
-			t.Errorf("expected description='Deploy the app', got %v", resp["description"])
-		}
-
 		inputs := resp["input"].([]any)
-		if len(inputs) != 2 {
-			t.Fatalf("expected 2 inputs, got %d", len(inputs))
-		}
-
 		instanceInput := inputs[1].(map[string]any)
 		if instanceInput["values_url"] != true {
 			t.Errorf("expected values_url=true, got %v", instanceInput["values_url"])
+		}
+		if _, hasValues := instanceInput["values"]; hasValues {
+			t.Error("expected no values when no identity provided")
+		}
+	})
+
+	t.Run("with identity resolves values", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/tasks/deploy", nil)
+		req.SetPathValue("name", "deploy")
+		req.Header.Set("X-Forwarded-User", "alice")
+		rec := httptest.NewRecorder()
+
+		s.handleGetTaskDef(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+		}
+
+		var resp map[string]any
+		json.Unmarshal(rec.Body.Bytes(), &resp)
+
+		inputs := resp["input"].([]any)
+		instanceInput := inputs[1].(map[string]any)
+
+		values, ok := instanceInput["values"].([]any)
+		if !ok {
+			t.Fatalf("expected values array, got %v", instanceInput["values"])
+		}
+		if len(values) != 2 {
+			t.Fatalf("expected 2 values, got %d", len(values))
+		}
+
+		first := values[0].(map[string]any)
+		if first["name"] != "DB One" || first["value"] != "db-001" {
+			t.Errorf("expected first value {DB One, db-001}, got %v", first)
 		}
 	})
 
@@ -1163,46 +1163,6 @@ func TestHandleSubmitTaskValuesURLError(t *testing.T) {
 			t.Errorf("expected status %d, got %d: %s", http.StatusBadGateway, rec.Code, rec.Body.String())
 		}
 	})
-}
-
-func TestHandleListTasksValuesURL(t *testing.T) {
-	mr := miniredis.RunT(t)
-	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
-	defer rdb.Close()
-
-	tasksConfig := &tasks.TasksConfig{
-		Tasks: map[string]tasks.TaskDef{
-			"upgrade-db": {
-				Script:      "upgrade.sh",
-				Description: "Upgrade DB",
-				Input: []tasks.Input{
-					{Name: "instance", Env: "INSTANCE", Type: "string", ValuesURL: "http://example.com/values"},
-				},
-			},
-		},
-	}
-
-	s := &Server{
-		cfg:   &config.Config{},
-		tasks: tasksConfig,
-		rdb:   rdb,
-	}
-
-	req := httptest.NewRequest(http.MethodGet, "/tasks", nil)
-	rec := httptest.NewRecorder()
-
-	s.handleListTasks(rec, req)
-
-	var resp map[string]any
-	json.Unmarshal(rec.Body.Bytes(), &resp)
-
-	task := resp["tasks"].(map[string]any)["upgrade-db"].(map[string]any)
-	inputs := task["input"].([]any)
-	input := inputs[0].(map[string]any)
-
-	if input["values_url"] != true {
-		t.Errorf("expected values_url=true in list response, got %v", input["values_url"])
-	}
 }
 
 func TestHandleGetLogs(t *testing.T) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -279,6 +279,73 @@ func TestHandleListTasks(t *testing.T) {
 	}
 }
 
+func TestHandleGetTaskDef(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	tasksConfig := &tasks.TasksConfig{
+		Tasks: map[string]tasks.TaskDef{
+			"deploy": {
+				Script:      "deploy.sh",
+				Description: "Deploy the app",
+				Timeout:     "5m",
+				Input: []tasks.Input{
+					{Name: "env", Env: "ENV", Type: "string", Required: true, Enum: []string{"dev", "prod"}},
+					{Name: "instance", Env: "INSTANCE", Type: "string", ValuesURL: "http://example.com/values"},
+				},
+			},
+		},
+	}
+
+	s := &Server{
+		cfg:   &config.Config{},
+		tasks: tasksConfig,
+		rdb:   rdb,
+	}
+
+	t.Run("existing task", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/tasks/deploy", nil)
+		req.SetPathValue("name", "deploy")
+		rec := httptest.NewRecorder()
+
+		s.handleGetTaskDef(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("expected status %d, got %d", http.StatusOK, rec.Code)
+		}
+
+		var resp map[string]any
+		json.Unmarshal(rec.Body.Bytes(), &resp)
+
+		if resp["description"] != "Deploy the app" {
+			t.Errorf("expected description='Deploy the app', got %v", resp["description"])
+		}
+
+		inputs := resp["input"].([]any)
+		if len(inputs) != 2 {
+			t.Fatalf("expected 2 inputs, got %d", len(inputs))
+		}
+
+		instanceInput := inputs[1].(map[string]any)
+		if instanceInput["values_url"] != true {
+			t.Errorf("expected values_url=true, got %v", instanceInput["values_url"])
+		}
+	})
+
+	t.Run("unknown task", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/tasks/nonexistent", nil)
+		req.SetPathValue("name", "nonexistent")
+		rec := httptest.NewRecorder()
+
+		s.handleGetTaskDef(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Errorf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+		}
+	})
+}
+
 func TestHandleSubmitTaskNotFound(t *testing.T) {
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -396,7 +463,7 @@ func TestHandleSubmitTaskValidationError(t *testing.T) {
 	}
 }
 
-func TestHandleGetTaskNotFound(t *testing.T) {
+func TestHandleGetExecutionNotFound(t *testing.T) {
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	defer rdb.Close()
@@ -415,7 +482,7 @@ func TestHandleGetTaskNotFound(t *testing.T) {
 	req.SetPathValue("id", "nonexistent-id")
 	rec := httptest.NewRecorder()
 
-	s.handleGetTask(rec, req)
+	s.handleGetExecution(rec, req)
 
 	if rec.Code != http.StatusNotFound {
 		t.Errorf("expected status %d, got %d", http.StatusNotFound, rec.Code)
@@ -557,7 +624,7 @@ func TestHandleSubmitTaskIdentityOptional(t *testing.T) {
 	}
 }
 
-func TestHandleGetTaskIdentity(t *testing.T) {
+func TestHandleGetExecutionIdentity(t *testing.T) {
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	defer rdb.Close()
@@ -597,7 +664,7 @@ func TestHandleGetTaskIdentity(t *testing.T) {
 	req.SetPathValue("id", info.ID)
 	rec := httptest.NewRecorder()
 
-	s.handleGetTask(rec, req)
+	s.handleGetExecution(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())
@@ -613,7 +680,7 @@ func TestHandleGetTaskIdentity(t *testing.T) {
 	}
 }
 
-func TestHandleGetTaskNoIdentity(t *testing.T) {
+func TestHandleGetExecutionNoIdentity(t *testing.T) {
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
 	defer rdb.Close()
@@ -651,7 +718,7 @@ func TestHandleGetTaskNoIdentity(t *testing.T) {
 	req.SetPathValue("id", info.ID)
 	rec := httptest.NewRecorder()
 
-	s.handleGetTask(rec, req)
+	s.handleGetExecution(rec, req)
 
 	if rec.Code != http.StatusOK {
 		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, rec.Code, rec.Body.String())

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -950,6 +950,194 @@ func TestHasAnyGroup(t *testing.T) {
 	}
 }
 
+func TestHandleSubmitTaskValuesURL(t *testing.T) {
+	valueSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user := r.URL.Query().Get("user")
+		switch user {
+		case "alice":
+			json.NewEncoder(w).Encode([]string{"db-001", "db-002"})
+		case "bob":
+			json.NewEncoder(w).Encode([]string{"db-003"})
+		default:
+			json.NewEncoder(w).Encode([]string{})
+		}
+	}))
+	defer valueSrv.Close()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	tasksConfig := &tasks.TasksConfig{
+		Tasks: map[string]tasks.TaskDef{
+			"upgrade-db": {
+				Script: "upgrade.sh",
+				Input: []tasks.Input{
+					{
+						Name:      "instance",
+						Env:       "DB_INSTANCE",
+						Required:  true,
+						Type:      "string",
+						ValuesURL: valueSrv.URL + "?user=${identity}",
+					},
+				},
+			},
+		},
+	}
+
+	s := &Server{
+		cfg: &config.Config{
+			IdentityHeader: "X-Forwarded-User",
+			GroupsHeader:   "X-Forwarded-Groups",
+		},
+		tasks:     tasksConfig,
+		rdb:       rdb,
+		logStream: logs.NewLogStreamer(rdb, time.Hour),
+		client:    asynq.NewClient(asynq.RedisClientOpt{Addr: mr.Addr()}),
+	}
+	defer s.client.Close()
+
+	t.Run("allowed value passes", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/upgrade-db",
+			strings.NewReader(`{"instance": "db-001"}`))
+		req.SetPathValue("name", "upgrade-db")
+		req.Header.Set("X-Forwarded-User", "alice")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Errorf("expected status %d, got %d: %s", http.StatusAccepted, rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("disallowed value returns 403", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/upgrade-db",
+			strings.NewReader(`{"instance": "db-003"}`))
+		req.SetPathValue("name", "upgrade-db")
+		req.Header.Set("X-Forwarded-User", "alice")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected status %d, got %d: %s", http.StatusForbidden, rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("different user sees different values", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/upgrade-db",
+			strings.NewReader(`{"instance": "db-003"}`))
+		req.SetPathValue("name", "upgrade-db")
+		req.Header.Set("X-Forwarded-User", "bob")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Errorf("expected status %d, got %d: %s", http.StatusAccepted, rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("unknown user gets empty list returns 403", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/upgrade-db",
+			strings.NewReader(`{"instance": "db-001"}`))
+		req.SetPathValue("name", "upgrade-db")
+		req.Header.Set("X-Forwarded-User", "unknown")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected status %d, got %d: %s", http.StatusForbidden, rec.Code, rec.Body.String())
+		}
+	})
+}
+
+func TestHandleSubmitTaskValuesURLError(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	t.Run("remote server error returns 502", func(t *testing.T) {
+		errSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer errSrv.Close()
+
+		tasksConfig := &tasks.TasksConfig{
+			Tasks: map[string]tasks.TaskDef{
+				"test": {
+					Script: "test.sh",
+					Input: []tasks.Input{
+						{Name: "val", Env: "VAL", Type: "string", ValuesURL: errSrv.URL},
+					},
+				},
+			},
+		}
+
+		s := &Server{
+			cfg:       &config.Config{IdentityHeader: "X-Forwarded-User"},
+			tasks:     tasksConfig,
+			rdb:       rdb,
+			logStream: logs.NewLogStreamer(rdb, time.Hour),
+			client:    asynq.NewClient(asynq.RedisClientOpt{Addr: mr.Addr()}),
+		}
+		defer s.client.Close()
+
+		req := httptest.NewRequest(http.MethodPost, "/tasks/test",
+			strings.NewReader(`{"val": "x"}`))
+		req.SetPathValue("name", "test")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusBadGateway {
+			t.Errorf("expected status %d, got %d: %s", http.StatusBadGateway, rec.Code, rec.Body.String())
+		}
+	})
+}
+
+func TestHandleListTasksValuesURL(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	defer rdb.Close()
+
+	tasksConfig := &tasks.TasksConfig{
+		Tasks: map[string]tasks.TaskDef{
+			"upgrade-db": {
+				Script:      "upgrade.sh",
+				Description: "Upgrade DB",
+				Input: []tasks.Input{
+					{Name: "instance", Env: "INSTANCE", Type: "string", ValuesURL: "http://example.com/values"},
+				},
+			},
+		},
+	}
+
+	s := &Server{
+		cfg:   &config.Config{},
+		tasks: tasksConfig,
+		rdb:   rdb,
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/tasks", nil)
+	rec := httptest.NewRecorder()
+
+	s.handleListTasks(rec, req)
+
+	var resp map[string]any
+	json.Unmarshal(rec.Body.Bytes(), &resp)
+
+	task := resp["tasks"].(map[string]any)["upgrade-db"].(map[string]any)
+	inputs := task["input"].([]any)
+	input := inputs[0].(map[string]any)
+
+	if input["values_url"] != true {
+		t.Errorf("expected values_url=true in list response, got %v", input["values_url"])
+	}
+}
+
 func TestHandleGetLogs(t *testing.T) {
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})

--- a/internal/api/values.go
+++ b/internal/api/values.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -16,6 +17,36 @@ const defaultValuesURLTimeout = 5 * time.Second
 type AllowedValue struct {
 	Name  string
 	Value string
+}
+
+type cacheEntry struct {
+	values    []AllowedValue
+	expiresAt time.Time
+}
+
+type valuesCache struct {
+	mu      sync.RWMutex
+	entries map[string]cacheEntry
+}
+
+func newValuesCache() *valuesCache {
+	return &valuesCache{entries: make(map[string]cacheEntry)}
+}
+
+func (c *valuesCache) get(key string) ([]AllowedValue, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, ok := c.entries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil, false
+	}
+	return entry.values, true
+}
+
+func (c *valuesCache) set(key string, values []AllowedValue, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = cacheEntry{values: values, expiresAt: time.Now().Add(ttl)}
 }
 
 func substituteURL(template, identity, groups, task string) string {

--- a/internal/api/values.go
+++ b/internal/api/values.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const defaultValuesURLTimeout = 5 * time.Second
+
+type AllowedValue struct {
+	Name  string
+	Value string
+}
+
+func substituteURL(template, identity, groups, task string) string {
+	r := strings.NewReplacer(
+		"${identity}", url.QueryEscape(identity),
+		"${groups}", url.QueryEscape(groups),
+		"${task}", url.QueryEscape(task),
+	)
+	return r.Replace(template)
+}
+
+func fetchAllowedValues(ctx context.Context, rawURL string) ([]AllowedValue, error) {
+	return fetchAllowedValuesWithTimeout(ctx, rawURL, defaultValuesURLTimeout)
+}
+
+func fetchAllowedValuesWithTimeout(ctx context.Context, rawURL string, timeout time.Duration) ([]AllowedValue, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("timeout fetching values from %s", rawURL)
+		}
+		return nil, fmt.Errorf("fetching values: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("values URL returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB limit
+	if err != nil {
+		return nil, fmt.Errorf("reading values response: %w", err)
+	}
+
+	return parseValuesResponse(body)
+}
+
+func parseValuesResponse(body []byte) ([]AllowedValue, error) {
+	// Try name-value array: [{"name": "...", "value": "..."}]
+	var nvList []struct {
+		Name  string `json:"name"`
+		Value string `json:"value"`
+	}
+	if err := json.Unmarshal(body, &nvList); err == nil && len(nvList) > 0 && nvList[0].Value != "" {
+		result := make([]AllowedValue, len(nvList))
+		for i, nv := range nvList {
+			result[i] = AllowedValue{Name: nv.Name, Value: nv.Value}
+		}
+		return result, nil
+	}
+
+	// Try simple string array: ["value1", "value2"]
+	var strList []string
+	if err := json.Unmarshal(body, &strList); err == nil {
+		result := make([]AllowedValue, len(strList))
+		for i, s := range strList {
+			result[i] = AllowedValue{Name: s, Value: s}
+		}
+		return result, nil
+	}
+
+	// Try key-value object: {"Label": "value"}
+	var kvMap map[string]string
+	if err := json.Unmarshal(body, &kvMap); err == nil {
+		result := make([]AllowedValue, 0, len(kvMap))
+		for name, value := range kvMap {
+			result = append(result, AllowedValue{Name: name, Value: value})
+		}
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("invalid values response format")
+}
+
+func isValueAllowed(submitted string, allowed []AllowedValue) bool {
+	for _, av := range allowed {
+		if av.Value == submitted {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/values.go
+++ b/internal/api/values.go
@@ -49,13 +49,16 @@ func (c *valuesCache) set(key string, values []AllowedValue, ttl time.Duration) 
 	c.entries[key] = cacheEntry{values: values, expiresAt: time.Now().Add(ttl)}
 }
 
-func substituteURL(template, identity, groups, task string) string {
-	r := strings.NewReplacer(
+func substituteURL(template, identity, groups, task string, inputValues map[string]string) string {
+	pairs := []string{
 		"${identity}", url.QueryEscape(identity),
 		"${groups}", url.QueryEscape(groups),
 		"${task}", url.QueryEscape(task),
-	)
-	return r.Replace(template)
+	}
+	for k, v := range inputValues {
+		pairs = append(pairs, "${input."+k+"}", url.QueryEscape(v))
+	}
+	return strings.NewReplacer(pairs...).Replace(template)
 }
 
 func fetchAllowedValues(ctx context.Context, rawURL string) ([]AllowedValue, error) {

--- a/internal/api/values.go
+++ b/internal/api/values.go
@@ -34,10 +34,14 @@ func newValuesCache() *valuesCache {
 }
 
 func (c *valuesCache) get(key string) ([]AllowedValue, bool) {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	entry, ok := c.entries[key]
-	if !ok || time.Now().After(entry.expiresAt) {
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		delete(c.entries, key)
 		return nil, false
 	}
 	return entry.values, true

--- a/internal/api/values_test.go
+++ b/internal/api/values_test.go
@@ -12,12 +12,13 @@ import (
 
 func TestSubstituteURL(t *testing.T) {
 	tests := []struct {
-		name     string
-		template string
-		identity string
-		groups   string
-		task     string
-		want     string
+		name        string
+		template    string
+		identity    string
+		groups      string
+		task        string
+		inputValues map[string]string
+		want        string
 	}{
 		{
 			name:     "all variables",
@@ -51,11 +52,37 @@ func TestSubstituteURL(t *testing.T) {
 			task:     "test",
 			want:     "http://authz/values?user=system%3Aserviceaccount%3Adefault%3Adeploy-bot",
 		},
+		{
+			name:        "input variable substitution",
+			template:    "http://authz/instances?region=${input.region}&user=${identity}",
+			identity:    "alice",
+			groups:      "",
+			task:        "upgrade-db",
+			inputValues: map[string]string{"region": "us-east-1"},
+			want:        "http://authz/instances?region=us-east-1&user=alice",
+		},
+		{
+			name:        "input variable with special chars",
+			template:    "http://authz/instances?region=${input.region}",
+			identity:    "",
+			groups:      "",
+			task:        "test",
+			inputValues: map[string]string{"region": "us east/1"},
+			want:        "http://authz/instances?region=us+east%2F1",
+		},
+		{
+			name:     "unresolved input variable preserved",
+			template: "http://authz/instances?region=${input.region}",
+			identity: "",
+			groups:   "",
+			task:     "test",
+			want:     "http://authz/instances?region=${input.region}",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := substituteURL(tt.template, tt.identity, tt.groups, tt.task)
+			got := substituteURL(tt.template, tt.identity, tt.groups, tt.task, tt.inputValues)
 			if got != tt.want {
 				t.Errorf("substituteURL() = %q, want %q", got, tt.want)
 			}
@@ -215,7 +242,7 @@ func TestFetchAllowedValues(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		url := substituteURL(srv.URL+"?user=${identity}&groups=${groups}", "alice", "ops,dev", "test")
+		url := substituteURL(srv.URL+"?user=${identity}&groups=${groups}", "alice", "ops,dev", "test", nil)
 		_, err := fetchAllowedValues(context.Background(), url)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/internal/api/values_test.go
+++ b/internal/api/values_test.go
@@ -228,3 +228,56 @@ func TestFetchAllowedValues(t *testing.T) {
 		}
 	})
 }
+
+func TestValuesCache(t *testing.T) {
+	t.Run("cache hit", func(t *testing.T) {
+		c := newValuesCache()
+		values := []AllowedValue{{Name: "a", Value: "1"}}
+		c.set("http://example.com", values, 1*time.Minute)
+
+		got, ok := c.get("http://example.com")
+		if !ok {
+			t.Fatal("expected cache hit")
+		}
+		if len(got) != 1 || got[0].Value != "1" {
+			t.Errorf("unexpected cached value: %v", got)
+		}
+	})
+
+	t.Run("cache miss", func(t *testing.T) {
+		c := newValuesCache()
+		_, ok := c.get("http://example.com")
+		if ok {
+			t.Error("expected cache miss")
+		}
+	})
+
+	t.Run("cache expired", func(t *testing.T) {
+		c := newValuesCache()
+		values := []AllowedValue{{Name: "a", Value: "1"}}
+		c.set("http://example.com", values, 1*time.Millisecond)
+
+		time.Sleep(2 * time.Millisecond)
+
+		_, ok := c.get("http://example.com")
+		if ok {
+			t.Error("expected cache miss after expiry")
+		}
+	})
+
+	t.Run("different keys", func(t *testing.T) {
+		c := newValuesCache()
+		c.set("http://example.com?user=alice", []AllowedValue{{Value: "a"}}, 1*time.Minute)
+		c.set("http://example.com?user=bob", []AllowedValue{{Value: "b"}}, 1*time.Minute)
+
+		alice, _ := c.get("http://example.com?user=alice")
+		bob, _ := c.get("http://example.com?user=bob")
+
+		if alice[0].Value != "a" {
+			t.Errorf("expected alice value 'a', got %q", alice[0].Value)
+		}
+		if bob[0].Value != "b" {
+			t.Errorf("expected bob value 'b', got %q", bob[0].Value)
+		}
+	})
+}

--- a/internal/api/values_test.go
+++ b/internal/api/values_test.go
@@ -1,0 +1,230 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSubstituteURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		template string
+		identity string
+		groups   string
+		task     string
+		want     string
+	}{
+		{
+			name:     "all variables",
+			template: "http://authz/values?user=${identity}&groups=${groups}&task=${task}",
+			identity: "alice@example.com",
+			groups:   "ops,dev",
+			task:     "upgrade-db",
+			want:     "http://authz/values?user=alice%40example.com&groups=ops%2Cdev&task=upgrade-db",
+		},
+		{
+			name:     "no variables",
+			template: "http://authz/values",
+			identity: "alice",
+			groups:   "ops",
+			task:     "test",
+			want:     "http://authz/values",
+		},
+		{
+			name:     "empty identity",
+			template: "http://authz/values?user=${identity}",
+			identity: "",
+			groups:   "",
+			task:     "test",
+			want:     "http://authz/values?user=",
+		},
+		{
+			name:     "k8s service account",
+			template: "http://authz/values?user=${identity}",
+			identity: "system:serviceaccount:default:deploy-bot",
+			groups:   "",
+			task:     "test",
+			want:     "http://authz/values?user=system%3Aserviceaccount%3Adefault%3Adeploy-bot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := substituteURL(tt.template, tt.identity, tt.groups, tt.task)
+			if got != tt.want {
+				t.Errorf("substituteURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseValuesResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		want    []AllowedValue
+		wantErr bool
+	}{
+		{
+			name: "simple list",
+			body: `["prod-db-001", "prod-db-002"]`,
+			want: []AllowedValue{
+				{Name: "prod-db-001", Value: "prod-db-001"},
+				{Name: "prod-db-002", Value: "prod-db-002"},
+			},
+		},
+		{
+			name: "name-value pairs",
+			body: `[{"name": "Production DB 001", "value": "prod-db-001"}, {"name": "Production DB 002", "value": "prod-db-002"}]`,
+			want: []AllowedValue{
+				{Name: "Production DB 001", Value: "prod-db-001"},
+				{Name: "Production DB 002", Value: "prod-db-002"},
+			},
+		},
+		{
+			name: "key-value object",
+			body: `{"Production DB 001": "prod-db-001"}`,
+			want: []AllowedValue{
+				{Name: "Production DB 001", Value: "prod-db-001"},
+			},
+		},
+		{
+			name: "empty array",
+			body: `[]`,
+			want: []AllowedValue{},
+		},
+		{
+			name:    "invalid json",
+			body:    `not json`,
+			wantErr: true,
+		},
+		{
+			name:    "number",
+			body:    `42`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseValuesResponse([]byte(tt.body))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseValuesResponse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("parseValuesResponse() returned %d values, want %d", len(got), len(tt.want))
+				return
+			}
+			for i, g := range got {
+				if g.Name != tt.want[i].Name || g.Value != tt.want[i].Value {
+					t.Errorf("parseValuesResponse()[%d] = %+v, want %+v", i, g, tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsValueAllowed(t *testing.T) {
+	allowed := []AllowedValue{
+		{Name: "DB 1", Value: "prod-db-001"},
+		{Name: "DB 2", Value: "prod-db-002"},
+	}
+
+	if !isValueAllowed("prod-db-001", allowed) {
+		t.Error("expected prod-db-001 to be allowed")
+	}
+	if isValueAllowed("prod-db-999", allowed) {
+		t.Error("expected prod-db-999 to be rejected")
+	}
+	if isValueAllowed("", allowed) {
+		t.Error("expected empty string to be rejected")
+	}
+}
+
+func TestFetchAllowedValues(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode([]string{"db-001", "db-002"})
+		}))
+		defer srv.Close()
+
+		values, err := fetchAllowedValues(context.Background(), srv.URL)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(values) != 2 {
+			t.Errorf("expected 2 values, got %d", len(values))
+		}
+	})
+
+	t.Run("non-200 status", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		_, err := fetchAllowedValues(context.Background(), srv.URL)
+		if err == nil {
+			t.Error("expected error for non-200 status")
+		}
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("not json"))
+		}))
+		defer srv.Close()
+
+		_, err := fetchAllowedValues(context.Background(), srv.URL)
+		if err == nil {
+			t.Error("expected error for invalid json")
+		}
+	})
+
+	t.Run("timeout returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(100 * time.Millisecond)
+			json.NewEncoder(w).Encode([]string{"db-001"})
+		}))
+		defer srv.Close()
+
+		_, err := fetchAllowedValuesWithTimeout(context.Background(), srv.URL, 1*time.Millisecond)
+		if err == nil {
+			t.Error("expected timeout error")
+		}
+		if !strings.Contains(err.Error(), "timeout") {
+			t.Errorf("expected timeout in error message, got %q", err.Error())
+		}
+	})
+
+	t.Run("passes user context in query", func(t *testing.T) {
+		var gotUser, gotGroups string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotUser = r.URL.Query().Get("user")
+			gotGroups = r.URL.Query().Get("groups")
+			json.NewEncoder(w).Encode([]string{"db-001"})
+		}))
+		defer srv.Close()
+
+		url := substituteURL(srv.URL+"?user=${identity}&groups=${groups}", "alice", "ops,dev", "test")
+		_, err := fetchAllowedValues(context.Background(), url)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotUser != "alice" {
+			t.Errorf("expected user=alice, got %q", gotUser)
+		}
+		if gotGroups != "ops,dev" {
+			t.Errorf("expected groups=ops,dev, got %q", gotGroups)
+		}
+	})
+}

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -47,6 +47,7 @@ type Input struct {
 	Default     string   `yaml:"default"`
 	Description string   `yaml:"description"`
 	ValuesURL   string   `yaml:"values_url"`
+	ValuesCache string   `yaml:"values_cache"`
 
 	compiledPattern *regexp.Regexp
 }
@@ -182,6 +183,14 @@ func Load(path string) (*TasksConfig, error) {
 		for _, input := range task.Input {
 			if input.ValuesURL != "" && len(input.Enum) > 0 {
 				return nil, fmt.Errorf("task %q input %q: values_url and enum are mutually exclusive", taskName, input.Name)
+			}
+			if input.ValuesCache != "" && input.ValuesURL == "" {
+				return nil, fmt.Errorf("task %q input %q: values_cache requires values_url", taskName, input.Name)
+			}
+			if input.ValuesCache != "" {
+				if _, err := time.ParseDuration(input.ValuesCache); err != nil {
+					return nil, fmt.Errorf("task %q input %q: invalid values_cache %q: %w", taskName, input.Name, input.ValuesCache, err)
+				}
 			}
 		}
 	}

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -46,6 +46,7 @@ type Input struct {
 	Max         *float64 `yaml:"max"`
 	Default     string   `yaml:"default"`
 	Description string   `yaml:"description"`
+	ValuesURL   string   `yaml:"values_url"`
 
 	compiledPattern *regexp.Regexp
 }
@@ -175,6 +176,14 @@ func Load(path string) (*TasksConfig, error) {
 	var cfg TasksConfig
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return nil, fmt.Errorf("parsing tasks config: %w", err)
+	}
+
+	for taskName, task := range cfg.Tasks {
+		for _, input := range task.Input {
+			if input.ValuesURL != "" && len(input.Enum) > 0 {
+				return nil, fmt.Errorf("task %q input %q: values_url and enum are mutually exclusive", taskName, input.Name)
+			}
+		}
 	}
 
 	return &cfg, nil

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -521,6 +521,73 @@ tasks:
 	}
 }
 
+func TestLoadValuesCacheValidation(t *testing.T) {
+	t.Run("valid values_cache", func(t *testing.T) {
+		content := `
+tasks:
+  test:
+    script: test.sh
+    input:
+      - name: instance
+        type: string
+        values_url: "http://example.com/values"
+        values_cache: 30s
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "tasks.yaml")
+		os.WriteFile(tmpFile, []byte(content), 0644)
+
+		cfg, err := Load(tmpFile)
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if cfg.Tasks["test"].Input[0].ValuesCache != "30s" {
+			t.Errorf("expected values_cache=30s, got %q", cfg.Tasks["test"].Input[0].ValuesCache)
+		}
+	})
+
+	t.Run("values_cache without values_url", func(t *testing.T) {
+		content := `
+tasks:
+  test:
+    script: test.sh
+    input:
+      - name: env
+        type: string
+        values_cache: 30s
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "tasks.yaml")
+		os.WriteFile(tmpFile, []byte(content), 0644)
+
+		_, err := Load(tmpFile)
+		if err == nil {
+			t.Error("expected error for values_cache without values_url")
+		}
+	})
+
+	t.Run("invalid values_cache duration", func(t *testing.T) {
+		content := `
+tasks:
+  test:
+    script: test.sh
+    input:
+      - name: instance
+        type: string
+        values_url: "http://example.com/values"
+        values_cache: notaduration
+`
+		tmpDir := t.TempDir()
+		tmpFile := filepath.Join(tmpDir, "tasks.yaml")
+		os.WriteFile(tmpFile, []byte(content), 0644)
+
+		_, err := Load(tmpFile)
+		if err == nil {
+			t.Error("expected error for invalid values_cache duration")
+		}
+	})
+}
+
 func ptr(f float64) *float64 {
 	return &f
 }

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -535,7 +535,9 @@ tasks:
 `
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "tasks.yaml")
-		os.WriteFile(tmpFile, []byte(content), 0644)
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
 
 		cfg, err := Load(tmpFile)
 		if err != nil {
@@ -558,7 +560,9 @@ tasks:
 `
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "tasks.yaml")
-		os.WriteFile(tmpFile, []byte(content), 0644)
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
 
 		_, err := Load(tmpFile)
 		if err == nil {
@@ -579,7 +583,9 @@ tasks:
 `
 		tmpDir := t.TempDir()
 		tmpFile := filepath.Join(tmpDir, "tasks.yaml")
-		os.WriteFile(tmpFile, []byte(content), 0644)
+		if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
 
 		_, err := Load(tmpFile)
 		if err == nil {

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -469,6 +469,58 @@ func TestValidatePayload(t *testing.T) {
 	})
 }
 
+func TestLoadMutualExclusion(t *testing.T) {
+	content := `
+tasks:
+  bad:
+    script: test.sh
+    input:
+      - name: env
+        env: ENV
+        type: string
+        enum: [dev, prod]
+        values_url: "http://example.com/values"
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "tasks.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(tmpFile)
+	if err == nil {
+		t.Error("expected error for values_url + enum")
+	}
+}
+
+func TestLoadWithValuesURL(t *testing.T) {
+	content := `
+tasks:
+  test:
+    script: test.sh
+    input:
+      - name: instance
+        env: INSTANCE
+        type: string
+        values_url: "http://authz.internal/instances?user=${identity}"
+`
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "tasks.yaml")
+	if err := os.WriteFile(tmpFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(tmpFile)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	task := cfg.Tasks["test"]
+	if task.Input[0].ValuesURL != "http://authz.internal/instances?user=${identity}" {
+		t.Errorf("expected values_url to be set, got %q", task.Input[0].ValuesURL)
+	}
+}
+
 func ptr(f float64) *float64 {
 	return &f
 }

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -79,6 +79,23 @@ tasks:
         values_url: "http://mock-values:8090/instances?user=${identity}"
         values_cache: 30s
 
+  upgrade-db-regional:
+    script: hello.sh
+    description: "Upgrade a database instance by region (cascading test)"
+    timeout: 1m
+    max_retry: 0
+    input:
+      - name: region
+        env: REGION
+        required: true
+        type: string
+        enum: [us-east-1, eu-west-1]
+      - name: instance
+        env: NAME
+        required: true
+        type: string
+        values_url: "http://mock-values:8090/instances-by-region?region=${input.region}"
+
   user-restricted:
     script: hello.sh
     description: "Task restricted to specific users"

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -77,6 +77,7 @@ tasks:
         required: true
         type: string
         values_url: "http://mock-values:8090/instances?user=${identity}"
+        values_cache: 30s
 
   user-restricted:
     script: hello.sh

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -66,6 +66,18 @@ tasks:
     max_retry: 0
     input: []
 
+  upgrade-db:
+    script: hello.sh
+    description: "Upgrade a database instance (values_url test)"
+    timeout: 1m
+    max_retry: 0
+    input:
+      - name: instance
+        env: NAME
+        required: true
+        type: string
+        values_url: "http://mock-values:8090/instances?user=${identity}"
+
   user-restricted:
     script: hello.sh
     description: "Task restricted to specific users"

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -553,22 +553,15 @@ test_allowed_users_or_groups() {
     fi
 }
 
-# Test: GET /tasks includes allowed_users in listing
-test_list_tasks_allowed_users() {
-    info "Testing GET /tasks includes allowed_users for user-restricted task"
-    RESP=$(curl -s "$BASE_URL/tasks")
-
-    # Check that user-restricted task has allowed_users with the expected value
-    if echo "$RESP" | grep -q '"user-restricted"'; then
-        pass "GET /tasks contains user-restricted task"
-    else
-        fail "GET /tasks contains user-restricted task" "user-restricted in response" "$RESP"
-    fi
+# Test: GET /tasks/{name} shows allowed_users
+test_get_task_def_allowed_users() {
+    info "Testing GET /tasks/user-restricted shows allowed_users"
+    RESP=$(curl -s "$BASE_URL/tasks/user-restricted")
 
     if echo "$RESP" | grep -q 'system:serviceaccount:default:deploy-bot'; then
-        pass "GET /tasks user-restricted has expected allowed_users value"
+        pass "GET /tasks/user-restricted has expected allowed_users value"
     else
-        fail "GET /tasks user-restricted has expected allowed_users value" "system:serviceaccount:default:deploy-bot" "$RESP"
+        fail "GET /tasks/user-restricted has expected allowed_users value" "system:serviceaccount:default:deploy-bot" "$RESP"
     fi
 }
 
@@ -658,7 +651,7 @@ echo "" >&2
 echo "--- Authorization Tests ---" >&2
 test_allowed_users
 test_allowed_users_or_groups
-test_list_tasks_allowed_users
+test_get_task_def_allowed_users
 test_values_url
 
 echo "" >&2

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -224,85 +224,85 @@ test_submit_unknown_task() {
     fi
 }
 
-# Test: GET /tasks/{id} - success result
+# Test: GET /executions/{id} - success result
 test_get_task_success() {
     local TASK_ID=$1
-    info "Testing GET /tasks/$TASK_ID (completed task)"
+    info "Testing GET /executions/$TASK_ID (completed task)"
 
     # Wait for task to complete
     sleep 5
 
-    RESP=$(curl -s "$BASE_URL/tasks/$TASK_ID")
+    RESP=$(curl -s "$BASE_URL/executions/$TASK_ID")
 
     if echo "$RESP" | grep -q '"status":"completed"'; then
-        pass "GET /tasks/$TASK_ID shows status=completed"
+        pass "GET /executions/$TASK_ID shows status=completed"
     else
-        fail "GET /tasks/$TASK_ID shows status=completed" "completed" "$RESP"
+        fail "GET /executions/$TASK_ID shows status=completed" "completed" "$RESP"
     fi
 
     if echo "$RESP" | grep -q '"exit_code":0'; then
-        pass "GET /tasks/$TASK_ID shows exit_code=0"
+        pass "GET /executions/$TASK_ID shows exit_code=0"
     else
-        fail "GET /tasks/$TASK_ID shows exit_code=0" "exit_code:0" "$RESP"
+        fail "GET /executions/$TASK_ID shows exit_code=0" "exit_code:0" "$RESP"
     fi
 
     # Check for created_at and started_at timestamps
     if echo "$RESP" | grep -q '"created_at"'; then
-        pass "GET /tasks/$TASK_ID shows created_at"
+        pass "GET /executions/$TASK_ID shows created_at"
     else
-        fail "GET /tasks/$TASK_ID shows created_at" '"created_at":"..."' "$RESP"
+        fail "GET /executions/$TASK_ID shows created_at" '"created_at":"..."' "$RESP"
     fi
 
     if echo "$RESP" | grep -q '"started_at"'; then
-        pass "GET /tasks/$TASK_ID shows started_at"
+        pass "GET /executions/$TASK_ID shows started_at"
     else
-        fail "GET /tasks/$TASK_ID shows started_at" '"started_at":"..."' "$RESP"
+        fail "GET /executions/$TASK_ID shows started_at" '"started_at":"..."' "$RESP"
     fi
 
     # Check for result data from AQSH_RESULT_FILE (stored as string)
     if echo "$RESP" | grep -q '"data":"'; then
-        pass "GET /tasks/$TASK_ID result contains data string"
+        pass "GET /executions/$TASK_ID result contains data string"
     else
-        fail "GET /tasks/$TASK_ID result contains data string" '"data":"..."' "$RESP"
+        fail "GET /executions/$TASK_ID result contains data string" '"data":"..."' "$RESP"
     fi
 
     # The data string should contain the greeted field (escaped JSON)
     if echo "$RESP" | grep -q 'greeted'; then
-        pass "GET /tasks/$TASK_ID result data contains greeted field"
+        pass "GET /executions/$TASK_ID result data contains greeted field"
     else
-        fail "GET /tasks/$TASK_ID result data contains greeted field" 'greeted' "$RESP"
+        fail "GET /executions/$TASK_ID result data contains greeted field" 'greeted' "$RESP"
     fi
 }
 
-# Test: GET /tasks/{id} - not found
+# Test: GET /executions/{id} - not found
 test_get_task_not_found() {
-    info "Testing GET /tasks/nonexistent-id (not found)"
-    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/tasks/nonexistent-id")
+    info "Testing GET /executions/nonexistent-id (not found)"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE_URL/executions/nonexistent-id")
 
     if [ "$HTTP_CODE" = "404" ]; then
-        pass "GET /tasks/nonexistent-id returns 404"
+        pass "GET /executions/nonexistent-id returns 404"
     else
-        fail "GET /tasks/nonexistent-id returns 404" "404" "$HTTP_CODE"
+        fail "GET /executions/nonexistent-id returns 404" "404" "$HTTP_CODE"
     fi
 }
 
-# Test: GET /tasks/{id}/logs - log streaming
+# Test: GET /executions/{id}/logs - log streaming
 test_get_task_logs() {
     local TASK_ID=$1
-    info "Testing GET /tasks/$TASK_ID/logs (log streaming)"
+    info "Testing GET /executions/$TASK_ID/logs (log streaming)"
 
-    RESP=$(curl -s "$BASE_URL/tasks/$TASK_ID/logs")
+    RESP=$(curl -s "$BASE_URL/executions/$TASK_ID/logs")
 
     if echo "$RESP" | grep -q 'Hello, IntegrationTest'; then
-        pass "GET /tasks/$TASK_ID/logs contains output"
+        pass "GET /executions/$TASK_ID/logs contains output"
     else
-        fail "GET /tasks/$TASK_ID/logs contains output" "Hello, IntegrationTest" "$RESP"
+        fail "GET /executions/$TASK_ID/logs contains output" "Hello, IntegrationTest" "$RESP"
     fi
 
     if echo "$RESP" | grep -q 'event: eof'; then
-        pass "GET /tasks/$TASK_ID/logs ends with EOF event"
+        pass "GET /executions/$TASK_ID/logs ends with EOF event"
     else
-        fail "GET /tasks/$TASK_ID/logs ends with EOF event" "event: eof" "$RESP"
+        fail "GET /executions/$TASK_ID/logs ends with EOF event" "event: eof" "$RESP"
     fi
 }
 
@@ -327,7 +327,7 @@ test_realtime_log_streaming() {
     sleep 1  # Give task a moment to start
 
     # Stream logs for 3 seconds while task is still running
-    LOGS=$(timeout 3 curl -s -N "$BASE_URL/tasks/$TASK_ID/logs" 2>/dev/null || true)
+    LOGS=$(timeout 3 curl -s -N "$BASE_URL/executions/$TASK_ID/logs" 2>/dev/null || true)
 
     # Check that we got some intermediate output (not just EOF)
     if echo "$LOGS" | grep -q 'Step 1 of 5'; then
@@ -340,7 +340,7 @@ test_realtime_log_streaming() {
     sleep 5
 
     # Now get complete logs
-    LOGS=$(curl -s "$BASE_URL/tasks/$TASK_ID/logs")
+    LOGS=$(curl -s "$BASE_URL/executions/$TASK_ID/logs")
 
     if echo "$LOGS" | grep -q 'Step 5 of 5'; then
         pass "Complete logs contain final step"
@@ -374,7 +374,7 @@ test_deploy_task() {
 
         # Wait and check result
         sleep 5
-        RESP=$(curl -s "$BASE_URL/tasks/$TASK_ID")
+        RESP=$(curl -s "$BASE_URL/executions/$TASK_ID")
 
         if echo "$RESP" | grep -q '"status":"completed"'; then
             pass "Deploy task completed successfully"
@@ -412,7 +412,7 @@ test_deploy_task_dry_run() {
 
         # Wait and check result
         sleep 3
-        RESP=$(curl -s "$BASE_URL/tasks/$TASK_ID")
+        RESP=$(curl -s "$BASE_URL/executions/$TASK_ID")
 
         if echo "$RESP" | grep -q '"status":"completed"'; then
             pass "Deploy dry_run task completed successfully"
@@ -444,7 +444,7 @@ test_task_no_result_file() {
 
         # Wait for task to complete
         sleep 7
-        RESP=$(curl -s "$BASE_URL/tasks/$TASK_ID")
+        RESP=$(curl -s "$BASE_URL/executions/$TASK_ID")
 
         if echo "$RESP" | grep -q '"status":"completed"'; then
             pass "Slow task completed successfully"
@@ -572,6 +572,65 @@ test_list_tasks_allowed_users() {
     fi
 }
 
+# Test: values_url authorization
+test_values_url() {
+    # Allowed user submits allowed value
+    info "Testing values_url: allowed user with allowed value"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -H "X-Forwarded-User: system:serviceaccount:default:deploy-bot" \
+        -d '{"instance": "db-001"}' \
+        "$BASE_URL/tasks/upgrade-db")
+
+    if [ "$HTTP_CODE" = "202" ]; then
+        pass "values_url: allowed user with allowed value returns 202"
+    else
+        fail "values_url: allowed user with allowed value returns 202" "202" "$HTTP_CODE"
+    fi
+
+    # Allowed user submits disallowed value
+    info "Testing values_url: allowed user with disallowed value"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -H "X-Forwarded-User: alice" \
+        -d '{"instance": "db-002"}' \
+        "$BASE_URL/tasks/upgrade-db")
+
+    if [ "$HTTP_CODE" = "403" ]; then
+        pass "values_url: allowed user with disallowed value returns 403"
+    else
+        fail "values_url: allowed user with disallowed value returns 403" "403" "$HTTP_CODE"
+    fi
+
+    # Allowed user submits their allowed value
+    info "Testing values_url: alice with her allowed value"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -H "X-Forwarded-User: alice" \
+        -d '{"instance": "db-001"}' \
+        "$BASE_URL/tasks/upgrade-db")
+
+    if [ "$HTTP_CODE" = "202" ]; then
+        pass "values_url: alice with her allowed value returns 202"
+    else
+        fail "values_url: alice with her allowed value returns 202" "202" "$HTTP_CODE"
+    fi
+
+    # Unknown user gets empty list, any value rejected
+    info "Testing values_url: unknown user rejected"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -H "X-Forwarded-User: unknown-user" \
+        -d '{"instance": "db-001"}' \
+        "$BASE_URL/tasks/upgrade-db")
+
+    if [ "$HTTP_CODE" = "403" ]; then
+        pass "values_url: unknown user returns 403"
+    else
+        fail "values_url: unknown user returns 403" "403" "$HTTP_CODE"
+    fi
+}
+
 # Main
 echo "========================================" >&2
 echo "aqsh Integration Tests" >&2
@@ -600,6 +659,7 @@ echo "--- Authorization Tests ---" >&2
 test_allowed_users
 test_allowed_users_or_groups
 test_list_tasks_allowed_users
+test_values_url
 
 echo "" >&2
 echo "--- Task Execution Tests ---" >&2

--- a/test/integration_test.sh
+++ b/test/integration_test.sh
@@ -624,6 +624,48 @@ test_values_url() {
     fi
 }
 
+# Test: cascading values_url (region -> instance)
+test_cascading_values_url() {
+    # Valid region + valid instance for that region
+    info "Testing cascading: us-east-1 with db-us-001"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"region": "us-east-1", "instance": "db-us-001"}' \
+        "$BASE_URL/tasks/upgrade-db-regional")
+
+    if [ "$HTTP_CODE" = "202" ]; then
+        pass "cascading: us-east-1 + db-us-001 returns 202"
+    else
+        fail "cascading: us-east-1 + db-us-001 returns 202" "202" "$HTTP_CODE"
+    fi
+
+    # Valid region + wrong instance (belongs to different region)
+    info "Testing cascading: us-east-1 with db-eu-001 (wrong region)"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"region": "us-east-1", "instance": "db-eu-001"}' \
+        "$BASE_URL/tasks/upgrade-db-regional")
+
+    if [ "$HTTP_CODE" = "403" ]; then
+        pass "cascading: us-east-1 + db-eu-001 returns 403"
+    else
+        fail "cascading: us-east-1 + db-eu-001 returns 403" "403" "$HTTP_CODE"
+    fi
+
+    # EU region + EU instance works
+    info "Testing cascading: eu-west-1 with db-eu-001"
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+        -H "Content-Type: application/json" \
+        -d '{"region": "eu-west-1", "instance": "db-eu-001"}' \
+        "$BASE_URL/tasks/upgrade-db-regional")
+
+    if [ "$HTTP_CODE" = "202" ]; then
+        pass "cascading: eu-west-1 + db-eu-001 returns 202"
+    else
+        fail "cascading: eu-west-1 + db-eu-001 returns 202" "202" "$HTTP_CODE"
+    fi
+}
+
 # Main
 echo "========================================" >&2
 echo "aqsh Integration Tests" >&2
@@ -653,6 +695,7 @@ test_allowed_users
 test_allowed_users_or_groups
 test_get_task_def_allowed_users
 test_values_url
+test_cascading_values_url
 
 echo "" >&2
 echo "--- Task Execution Tests ---" >&2

--- a/test/mock-values-server/server.py
+++ b/test/mock-values-server/server.py
@@ -7,12 +7,25 @@ ALLOWED_VALUES = {
     "alice": ["db-001"],
 }
 
+INSTANCES_BY_REGION = {
+    "us-east-1": ["db-us-001", "db-us-002"],
+    "eu-west-1": ["db-eu-001"],
+}
+
 
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
-        params = parse_qs(urlparse(self.path).query)
-        user = params.get("user", [""])[0]
-        values = ALLOWED_VALUES.get(user, [])
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+        path = parsed.path
+
+        if path == "/instances-by-region":
+            region = params.get("region", [""])[0]
+            values = INSTANCES_BY_REGION.get(region, [])
+        else:
+            user = params.get("user", [""])[0]
+            values = ALLOWED_VALUES.get(user, [])
+
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()

--- a/test/mock-values-server/server.py
+++ b/test/mock-values-server/server.py
@@ -1,0 +1,28 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, parse_qs
+import json
+
+ALLOWED_VALUES = {
+    "system:serviceaccount:default:deploy-bot": ["db-001", "db-002", "db-003"],
+    "alice": ["db-001"],
+}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        params = parse_qs(urlparse(self.path).query)
+        user = params.get("user", [""])[0]
+        values = ALLOWED_VALUES.get(user, [])
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(values).encode())
+
+    def log_message(self, format, *args):
+        pass
+
+
+if __name__ == "__main__":
+    server = HTTPServer(("0.0.0.0", 8090), Handler)
+    print("Mock values server listening on :8090", flush=True)
+    server.serve_forever()


### PR DESCRIPTION
## Summary

- Add `values_url` field to input definitions for per-parameter authorization via remote URL
- Separate API into task definitions (`/tasks/`) and executions (`/executions/`)
- Add `GET /tasks/{name}` endpoint that resolves allowed values when identity headers present
- Simplify `GET /tasks` to return name + description only
- Add in-memory TTL cache for values_url responses (`values_cache` per-input)
- Support cascading parameters — `${input.X}` references in values_url
- Mock Python values server for integration testing

## Breaking Changes

- `GET /tasks/{id}` → `GET /executions/{id}`
- `GET /tasks/{id}/logs` → `GET /executions/{id}/logs`
- `GET /tasks` response simplified to summary only

## Design

See `docs/input-rbac-design.md` for rationale, inspired by [Rundeck's Remote URL for option values](https://docs.rundeck.com/docs/manual/jobs/job-options.html#text-option-type).

## Test plan

- [x] Unit tests pass (79.7% coverage)
- [x] Integration tests pass (53 tests) including:
  - values_url authorization (4 tests)
  - Cascading parameters (3 tests)
- [x] Mutual exclusion: `values_url` + `enum` rejected at load time
- [x] `values_cache` validated (requires `values_url`, valid duration)
- [x] Remote URL errors return 502/504 appropriately