### PR TITLE
feat: support include globs in tasks.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,9 +15,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version-file: go.mod
 
@@ -26,7 +26,7 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - run: docker compose --profile dev up --build -d
 
@@ -38,9 +38,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: false
@@ -55,15 +55,15 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/metadata-action@v5
+      - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         id: meta
         with:
           images: ${{ env.IMAGE }}
@@ -71,7 +71,7 @@ jobs:
             type=semver,pattern={{version}}
             type=raw,value=latest
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         id: push
         with:
           context: .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
       AQSH_REDIS_ADDR: redis:6379
     volumes:
       - ./tasks.yaml:/etc/aqsh/tasks.yaml:ro
+      - ./tasks.d:/etc/aqsh/tasks.d:ro
       - ./tasks:/tasks:ro
     depends_on:
       - redis

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -196,16 +197,33 @@ func Load(path string) (*TasksConfig, error) {
 	}
 
 	baseDir := filepath.Dir(path)
+	absBaseDir, err := filepath.Abs(baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving base directory: %w", err)
+	}
+	loaded := make(map[string]bool)
 	for _, pattern := range cfg.Include {
-		if !filepath.IsAbs(pattern) {
-			pattern = filepath.Join(baseDir, pattern)
+		if filepath.IsAbs(pattern) {
+			return nil, fmt.Errorf("include pattern %q must be relative", pattern)
 		}
-		matches, err := filepath.Glob(pattern)
+		resolved := filepath.Clean(filepath.Join(absBaseDir, pattern))
+		if rel, err := filepath.Rel(absBaseDir, resolved); err != nil || strings.HasPrefix(rel, "..") {
+			return nil, fmt.Errorf("include pattern %q escapes base directory", pattern)
+		}
+		matches, err := filepath.Glob(resolved)
 		if err != nil {
 			return nil, fmt.Errorf("invalid include pattern %q: %w", pattern, err)
 		}
 		for _, match := range matches {
-			if err := loadInclude(&cfg, match, taskSources); err != nil {
+			absMatch, err := filepath.Abs(match)
+			if err != nil {
+				return nil, fmt.Errorf("resolving include file %q: %w", match, err)
+			}
+			if loaded[absMatch] {
+				continue
+			}
+			loaded[absMatch] = true
+			if err := loadInclude(&cfg, absMatch, taskSources); err != nil {
 				return nil, err
 			}
 		}
@@ -221,10 +239,18 @@ func loadInclude(cfg *TasksConfig, path string, taskSources map[string]string) e
 	}
 
 	var included struct {
-		Tasks map[string]TaskDef `yaml:"tasks"`
+		Include  []string           `yaml:"include"`
+		Defaults TaskDefaults       `yaml:"defaults"`
+		Tasks    map[string]TaskDef `yaml:"tasks"`
 	}
 	if err := yaml.Unmarshal(data, &included); err != nil {
 		return fmt.Errorf("parsing included file %q: %w", path, err)
+	}
+	if len(included.Include) > 0 {
+		return fmt.Errorf("included file %q must not define include", path)
+	}
+	if included.Defaults != (TaskDefaults{}) {
+		return fmt.Errorf("included file %q must not define defaults", path)
 	}
 
 	if err := validateInputs(included.Tasks); err != nil {

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"time"
@@ -11,6 +12,7 @@ import (
 )
 
 type TasksConfig struct {
+	Include  []string           `yaml:"include"`
 	Defaults TaskDefaults       `yaml:"defaults"`
 	Tasks    map[string]TaskDef `yaml:"tasks"`
 }
@@ -179,23 +181,85 @@ func Load(path string) (*TasksConfig, error) {
 		return nil, fmt.Errorf("parsing tasks config: %w", err)
 	}
 
-	for taskName, task := range cfg.Tasks {
-		for _, input := range task.Input {
-			if input.ValuesURL != "" && len(input.Enum) > 0 {
-				return nil, fmt.Errorf("task %q input %q: values_url and enum are mutually exclusive", taskName, input.Name)
-			}
-			if input.ValuesCache != "" && input.ValuesURL == "" {
-				return nil, fmt.Errorf("task %q input %q: values_cache requires values_url", taskName, input.Name)
-			}
-			if input.ValuesCache != "" {
-				if _, err := time.ParseDuration(input.ValuesCache); err != nil {
-					return nil, fmt.Errorf("task %q input %q: invalid values_cache %q: %w", taskName, input.Name, input.ValuesCache, err)
-				}
+	if cfg.Tasks == nil {
+		cfg.Tasks = make(map[string]TaskDef)
+	}
+
+	sourceFile := filepath.Base(path)
+	taskSources := make(map[string]string)
+	for taskName := range cfg.Tasks {
+		taskSources[taskName] = sourceFile
+	}
+
+	if err := validateInputs(cfg.Tasks); err != nil {
+		return nil, err
+	}
+
+	baseDir := filepath.Dir(path)
+	for _, pattern := range cfg.Include {
+		if !filepath.IsAbs(pattern) {
+			pattern = filepath.Join(baseDir, pattern)
+		}
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return nil, fmt.Errorf("invalid include pattern %q: %w", pattern, err)
+		}
+		for _, match := range matches {
+			if err := loadInclude(&cfg, match, taskSources); err != nil {
+				return nil, err
 			}
 		}
 	}
 
 	return &cfg, nil
+}
+
+func loadInclude(cfg *TasksConfig, path string, taskSources map[string]string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading included file %q: %w", path, err)
+	}
+
+	var included struct {
+		Tasks map[string]TaskDef `yaml:"tasks"`
+	}
+	if err := yaml.Unmarshal(data, &included); err != nil {
+		return fmt.Errorf("parsing included file %q: %w", path, err)
+	}
+
+	if err := validateInputs(included.Tasks); err != nil {
+		return err
+	}
+
+	source := filepath.Base(path)
+	for taskName, taskDef := range included.Tasks {
+		if existingSource, exists := taskSources[taskName]; exists {
+			return fmt.Errorf("task %q defined in both %s and %s", taskName, existingSource, source)
+		}
+		taskSources[taskName] = source
+		cfg.Tasks[taskName] = taskDef
+	}
+
+	return nil
+}
+
+func validateInputs(tasks map[string]TaskDef) error {
+	for taskName, task := range tasks {
+		for _, input := range task.Input {
+			if input.ValuesURL != "" && len(input.Enum) > 0 {
+				return fmt.Errorf("task %q input %q: values_url and enum are mutually exclusive", taskName, input.Name)
+			}
+			if input.ValuesCache != "" && input.ValuesURL == "" {
+				return fmt.Errorf("task %q input %q: values_cache requires values_url", taskName, input.Name)
+			}
+			if input.ValuesCache != "" {
+				if _, err := time.ParseDuration(input.ValuesCache); err != nil {
+					return fmt.Errorf("task %q input %q: invalid values_cache %q: %w", taskName, input.Name, input.ValuesCache, err)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (c *TasksConfig) Resolve(name string) (*ResolvedTask, error) {

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -594,6 +594,197 @@ tasks:
 	})
 }
 
+func TestLoadInclude(t *testing.T) {
+	t.Run("include merges tasks", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+include:
+  - "tasks.d/*.yaml"
+defaults:
+  timeout: 5m
+tasks:
+  hello:
+    script: hello.sh
+`
+		incl := `
+tasks:
+  deploy:
+    script: deploy.sh
+    description: "Deploy app"
+`
+		if err := os.MkdirAll(filepath.Join(tmpDir, "tasks.d"), 0755); err != nil {
+			t.Fatalf("MkdirAll error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.d", "deploy.yaml"), []byte(incl), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		cfg, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if _, ok := cfg.Tasks["hello"]; !ok {
+			t.Error("expected task 'hello' from main file")
+		}
+		if _, ok := cfg.Tasks["deploy"]; !ok {
+			t.Error("expected task 'deploy' from included file")
+		}
+		if cfg.Tasks["deploy"].Description != "Deploy app" {
+			t.Errorf("expected description 'Deploy app', got %q", cfg.Tasks["deploy"].Description)
+		}
+	})
+
+	t.Run("duplicate task rejected", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+include:
+  - "tasks.d/*.yaml"
+tasks:
+  hello:
+    script: hello.sh
+`
+		incl := `
+tasks:
+  hello:
+    script: other.sh
+`
+		if err := os.MkdirAll(filepath.Join(tmpDir, "tasks.d"), 0755); err != nil {
+			t.Fatalf("MkdirAll error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.d", "dupe.yaml"), []byte(incl), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		_, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err == nil {
+			t.Fatal("expected error for duplicate task")
+		}
+		if want := `task "hello" defined in both tasks.yaml and dupe.yaml`; err.Error() != want {
+			t.Errorf("expected error %q, got %q", want, err.Error())
+		}
+	})
+
+	t.Run("duplicate across included files", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+include:
+  - "tasks.d/*.yaml"
+tasks: {}
+`
+		file1 := `
+tasks:
+  deploy:
+    script: deploy.sh
+`
+		file2 := `
+tasks:
+  deploy:
+    script: other.sh
+`
+		if err := os.MkdirAll(filepath.Join(tmpDir, "tasks.d"), 0755); err != nil {
+			t.Fatalf("MkdirAll error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.d", "a.yaml"), []byte(file1), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.d", "b.yaml"), []byte(file2), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		_, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err == nil {
+			t.Fatal("expected error for duplicate task across includes")
+		}
+		if want := `task "deploy" defined in both a.yaml and b.yaml`; err.Error() != want {
+			t.Errorf("expected error %q, got %q", want, err.Error())
+		}
+	})
+
+	t.Run("empty glob matches nothing", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+include:
+  - "nonexistent/*.yaml"
+tasks:
+  hello:
+    script: hello.sh
+`
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		cfg, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if len(cfg.Tasks) != 1 {
+			t.Errorf("expected 1 task, got %d", len(cfg.Tasks))
+		}
+	})
+
+	t.Run("no include field", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+tasks:
+  hello:
+    script: hello.sh
+`
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		cfg, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if len(cfg.Tasks) != 1 {
+			t.Errorf("expected 1 task, got %d", len(cfg.Tasks))
+		}
+	})
+
+	t.Run("included file validation error", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+include:
+  - "tasks.d/*.yaml"
+tasks: {}
+`
+		incl := `
+tasks:
+  bad:
+    script: bad.sh
+    input:
+      - name: x
+        type: string
+        values_url: "http://example.com"
+        enum: [a, b]
+`
+		if err := os.MkdirAll(filepath.Join(tmpDir, "tasks.d"), 0755); err != nil {
+			t.Fatalf("MkdirAll error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.d", "bad.yaml"), []byte(incl), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		_, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err == nil {
+			t.Fatal("expected validation error from included file")
+		}
+	})
+}
+
 func ptr(f float64) *float64 {
 	return &f
 }

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -3,6 +3,7 @@ package tasks
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -781,6 +782,144 @@ tasks:
 		_, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
 		if err == nil {
 			t.Fatal("expected validation error from included file")
+		}
+	})
+
+	t.Run("absolute include pattern rejected", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+include:
+  - /etc/aqsh/tasks.d/*.yaml
+tasks: {}
+`
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		_, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err == nil {
+			t.Fatal("expected error for absolute include pattern")
+		}
+		if !strings.Contains(err.Error(), "must be relative") {
+			t.Errorf("expected 'must be relative' error, got %q", err.Error())
+		}
+	})
+
+	t.Run("path traversal rejected", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+include:
+  - "../other/*.yaml"
+tasks: {}
+`
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		_, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err == nil {
+			t.Fatal("expected error for path traversal")
+		}
+		if !strings.Contains(err.Error(), "escapes base directory") {
+			t.Errorf("expected 'escapes base directory' error, got %q", err.Error())
+		}
+	})
+
+	t.Run("duplicate glob matches deduplicated", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+include:
+  - "tasks.d/*.yaml"
+  - "tasks.d/deploy.yaml"
+tasks: {}
+`
+		incl := `
+tasks:
+  deploy:
+    script: deploy.sh
+`
+		if err := os.MkdirAll(filepath.Join(tmpDir, "tasks.d"), 0755); err != nil {
+			t.Fatalf("MkdirAll error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.d", "deploy.yaml"), []byte(incl), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		cfg, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err != nil {
+			t.Fatalf("Load() error = %v", err)
+		}
+		if _, ok := cfg.Tasks["deploy"]; !ok {
+			t.Error("expected task 'deploy'")
+		}
+	})
+
+	t.Run("included file with defaults rejected", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+include:
+  - "tasks.d/*.yaml"
+tasks: {}
+`
+		incl := `
+defaults:
+  timeout: 10m
+tasks:
+  deploy:
+    script: deploy.sh
+`
+		if err := os.MkdirAll(filepath.Join(tmpDir, "tasks.d"), 0755); err != nil {
+			t.Fatalf("MkdirAll error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.d", "bad.yaml"), []byte(incl), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		_, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err == nil {
+			t.Fatal("expected error for defaults in included file")
+		}
+		if !strings.Contains(err.Error(), "must not define defaults") {
+			t.Errorf("expected 'must not define defaults' error, got %q", err.Error())
+		}
+	})
+
+	t.Run("included file with nested include rejected", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		main := `
+include:
+  - "tasks.d/*.yaml"
+tasks: {}
+`
+		incl := `
+include:
+  - "more/*.yaml"
+tasks:
+  deploy:
+    script: deploy.sh
+`
+		if err := os.MkdirAll(filepath.Join(tmpDir, "tasks.d"), 0755); err != nil {
+			t.Fatalf("MkdirAll error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.yaml"), []byte(main), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "tasks.d", "bad.yaml"), []byte(incl), 0644); err != nil {
+			t.Fatalf("WriteFile error = %v", err)
+		}
+
+		_, err := Load(filepath.Join(tmpDir, "tasks.yaml"))
+		if err == nil {
+			t.Fatal("expected error for nested include")
+		}
+		if !strings.Contains(err.Error(), "must not define include") {
+			t.Errorf("expected 'must not define include' error, got %q", err.Error())
 		}
 	})
 }

--- a/tasks.d/test.yaml
+++ b/tasks.d/test.yaml
@@ -1,0 +1,55 @@
+tasks:
+  upgrade-db:
+    script: hello.sh
+    description: "Upgrade a database instance (values_url test)"
+    timeout: 1m
+    max_retry: 0
+    input:
+      - name: instance
+        env: NAME
+        required: true
+        type: string
+        values_url: "http://mock-values:8090/instances?user=${identity}"
+        values_cache: 30s
+
+  upgrade-db-regional:
+    script: hello.sh
+    description: "Upgrade a database instance by region (cascading test)"
+    timeout: 1m
+    max_retry: 0
+    input:
+      - name: region
+        env: REGION
+        required: true
+        type: string
+        enum: [us-east-1, eu-west-1]
+      - name: instance
+        env: NAME
+        required: true
+        type: string
+        values_url: "http://mock-values:8090/instances-by-region?region=${input.region}"
+
+  user-restricted:
+    script: hello.sh
+    description: "Task restricted to specific users"
+    timeout: 1m
+    max_retry: 0
+    allowed_users: ["system:serviceaccount:default:deploy-bot"]
+    input:
+      - name: name
+        env: NAME
+        required: true
+        type: string
+
+  user-or-group:
+    script: hello.sh
+    description: "Task restricted to specific users or groups"
+    timeout: 1m
+    max_retry: 0
+    allowed_users: ["system:serviceaccount:default:deploy-bot"]
+    allowed_groups: ["ops-team"]
+    input:
+      - name: name
+        env: NAME
+        required: true
+        type: string

--- a/tasks.yaml
+++ b/tasks.yaml
@@ -1,3 +1,6 @@
+include:
+  - tasks.d/*.yaml
+
 defaults:
   timeout: 5m
   max_retry: 3
@@ -65,58 +68,3 @@ tasks:
     timeout: 1m
     max_retry: 0
     input: []
-
-  upgrade-db:
-    script: hello.sh
-    description: "Upgrade a database instance (values_url test)"
-    timeout: 1m
-    max_retry: 0
-    input:
-      - name: instance
-        env: NAME
-        required: true
-        type: string
-        values_url: "http://mock-values:8090/instances?user=${identity}"
-        values_cache: 30s
-
-  upgrade-db-regional:
-    script: hello.sh
-    description: "Upgrade a database instance by region (cascading test)"
-    timeout: 1m
-    max_retry: 0
-    input:
-      - name: region
-        env: REGION
-        required: true
-        type: string
-        enum: [us-east-1, eu-west-1]
-      - name: instance
-        env: NAME
-        required: true
-        type: string
-        values_url: "http://mock-values:8090/instances-by-region?region=${input.region}"
-
-  user-restricted:
-    script: hello.sh
-    description: "Task restricted to specific users"
-    timeout: 1m
-    max_retry: 0
-    allowed_users: ["system:serviceaccount:default:deploy-bot"]
-    input:
-      - name: name
-        env: NAME
-        required: true
-        type: string
-
-  user-or-group:
-    script: hello.sh
-    description: "Task restricted to specific users or groups"
-    timeout: 1m
-    max_retry: 0
-    allowed_users: ["system:serviceaccount:default:deploy-bot"]
-    allowed_groups: ["ops-team"]
-    input:
-      - name: name
-        env: NAME
-        required: true
-        type: string


### PR DESCRIPTION
## Summary

- Add `include` field to `tasks.yaml` accepting glob patterns resolved relative to the config file
- Duplicate task names across files are rejected at load time with a clear error naming both source files
- Split test/example tasks into `tasks.d/test.yaml` to exercise the feature in integration tests

Closes #9

## Test plan

- [x] Unit tests: glob merge, duplicate detection (main vs include, include vs include), empty glob, no-include backward compat, validation error in included file
- [x] Integration tests: all 53 tests pass with split config (tasks loaded from both `tasks.yaml` and `tasks.d/test.yaml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task definitions can now be loaded from external YAML files via a new include directive.
  * Improved duplicate task name detection across base and included configurations.

* **Refactor**
  * Task configuration reorganized into modular external files for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/null-ptr-exception/aqsh/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->