### PR TITLE
feat: support default task authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,12 +439,26 @@ tasks:
     input: [...]
 ```
 
+You can also set default authorization for all tasks:
+
+```yaml
+defaults:
+  allowed_users: [system:serviceaccount:deploy:deployer]
+  allowed_groups: [deploy-team, platform-team]
+
+tasks:
+  deploy:
+    script: /tasks/deploy.sh
+    input: [...]
+```
+
 - `allowed_users` matches the identity header against the list (exact match).
 - `allowed_groups` matches the groups header (comma-separated) against the list.
 - If both are set, the request is authorized if **either** matches (OR logic). This mirrors Kubernetes RBAC `RoleBinding.subjects` semantics.
+- Task-level `allowed_users` or `allowed_groups` overrides the matching default. Set `allowed_users: []` or `allowed_groups: []` on a task to clear that default for the task.
 - Returns 403 if neither matches.
 
-Tasks without `allowed_users` or `allowed_groups` are open to all users (or all authenticated users when `AQSH_REQUIRE_IDENTITY=true`).
+Tasks without task-level or default `allowed_users` or `allowed_groups` are open to all users, or all authenticated users when `AQSH_REQUIRE_IDENTITY=true`.
 
 ### Trust Boundary
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -92,7 +92,7 @@ The identity header (default `X-Forwarded-User`, configurable via `AQSH_IDENTITY
 
 **Authorization:**
 
-Tasks can restrict access using `allowed_users` and/or `allowed_groups` in their config. If either matches, the request is authorized (OR logic). `allowed_users` matches against the identity header; `allowed_groups` matches against the groups header (comma-separated). If neither is configured, the task is open to all.
+Tasks can restrict access using task-level or default `allowed_users` and/or `allowed_groups` in their config. If either matches, the request is authorized (OR logic). `allowed_users` matches against the identity header; `allowed_groups` matches against the groups header (comma-separated). If neither is configured, the task is open to all.
 
 Inputs with `values_url` perform additional per-parameter authorization: the remote URL is fetched with user context, and the submitted value must be in the returned list.
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -740,13 +740,20 @@ func TestHandleSubmitTaskGroupAuthorization(t *testing.T) {
 	defer rdb.Close()
 
 	tasksConfig := &tasks.TasksConfig{
+		Defaults: tasks.TaskDefaults{
+			AllowedGroups: []string{"platform"},
+		},
 		Tasks: map[string]tasks.TaskDef{
 			"restricted": {
 				Script:        "restricted.sh",
-				AllowedGroups: []string{"admin", "ops"},
+				AllowedGroups: &[]string{"admin", "ops"},
 			},
 			"open": {
-				Script: "open.sh",
+				Script:        "open.sh",
+				AllowedGroups: &[]string{},
+			},
+			"inherited": {
+				Script: "inherited.sh",
 			},
 		},
 	}
@@ -813,6 +820,32 @@ func TestHandleSubmitTaskGroupAuthorization(t *testing.T) {
 		}
 	})
 
+	t.Run("default allowed group passes", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/inherited", strings.NewReader(`{}`))
+		req.SetPathValue("name", "inherited")
+		req.Header.Set("X-Forwarded-Groups", "dev,platform")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Errorf("expected status %d, got %d: %s", http.StatusAccepted, rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("default allowed group rejects non-member", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/inherited", strings.NewReader(`{}`))
+		req.SetPathValue("name", "inherited")
+		req.Header.Set("X-Forwarded-Groups", "dev,staging")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+		}
+	})
+
 	t.Run("groups with spaces trimmed", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/tasks/restricted", strings.NewReader(`{}`))
 		req.SetPathValue("name", "restricted")
@@ -833,15 +866,21 @@ func TestHandleSubmitTaskUserAuthorization(t *testing.T) {
 	defer rdb.Close()
 
 	tasksConfig := &tasks.TasksConfig{
+		Defaults: tasks.TaskDefaults{
+			AllowedUsers: []string{"platform-bot"},
+		},
 		Tasks: map[string]tasks.TaskDef{
 			"sa-only": {
 				Script:       "sa.sh",
-				AllowedUsers: []string{"system:serviceaccount:rdsma:sertdxkkk"},
+				AllowedUsers: &[]string{"system:serviceaccount:rdsma:sertdxkkk"},
 			},
 			"users-and-groups": {
 				Script:        "both.sh",
-				AllowedUsers:  []string{"alice"},
-				AllowedGroups: []string{"ops"},
+				AllowedUsers:  &[]string{"alice"},
+				AllowedGroups: &[]string{"ops"},
+			},
+			"inherited": {
+				Script: "inherited.sh",
 			},
 		},
 	}
@@ -887,6 +926,32 @@ func TestHandleSubmitTaskUserAuthorization(t *testing.T) {
 	t.Run("no identity returns 403 for user-restricted task", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPost, "/tasks/sa-only", strings.NewReader(`{}`))
 		req.SetPathValue("name", "sa-only")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+		}
+	})
+
+	t.Run("default allowed user passes", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/inherited", strings.NewReader(`{}`))
+		req.SetPathValue("name", "inherited")
+		req.Header.Set("X-Forwarded-User", "platform-bot")
+		rec := httptest.NewRecorder()
+
+		s.handleSubmitTask(rec, req)
+
+		if rec.Code != http.StatusAccepted {
+			t.Errorf("expected status %d, got %d: %s", http.StatusAccepted, rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("default allowed user rejects non-member", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/tasks/inherited", strings.NewReader(`{}`))
+		req.SetPathValue("name", "inherited")
+		req.Header.Set("X-Forwarded-User", "bob")
 		rec := httptest.NewRecorder()
 
 		s.handleSubmitTask(rec, req)

--- a/internal/tasks/tasks.go
+++ b/internal/tasks/tasks.go
@@ -19,23 +19,25 @@ type TasksConfig struct {
 }
 
 type TaskDefaults struct {
-	Timeout      string `yaml:"timeout"`
-	MaxRetry     int    `yaml:"max_retry"`
-	RetryDelay   string `yaml:"retry_delay"`
-	Queue        string `yaml:"queue"`
-	LogRetention string `yaml:"log_retention"`
+	Timeout       string   `yaml:"timeout"`
+	MaxRetry      int      `yaml:"max_retry"`
+	RetryDelay    string   `yaml:"retry_delay"`
+	Queue         string   `yaml:"queue"`
+	LogRetention  string   `yaml:"log_retention"`
+	AllowedUsers  []string `yaml:"allowed_users"`
+	AllowedGroups []string `yaml:"allowed_groups"`
 }
 
 type TaskDef struct {
-	Script        string   `yaml:"script"`
-	Description   string   `yaml:"description"`
-	Timeout       string   `yaml:"timeout"`
-	MaxRetry      *int     `yaml:"max_retry"`
-	RetryDelay    string   `yaml:"retry_delay"`
-	Queue         string   `yaml:"queue"`
-	AllowedUsers  []string `yaml:"allowed_users"`
-	AllowedGroups []string `yaml:"allowed_groups"`
-	Input         []Input  `yaml:"input"`
+	Script        string    `yaml:"script"`
+	Description   string    `yaml:"description"`
+	Timeout       string    `yaml:"timeout"`
+	MaxRetry      *int      `yaml:"max_retry"`
+	RetryDelay    string    `yaml:"retry_delay"`
+	Queue         string    `yaml:"queue"`
+	AllowedUsers  *[]string `yaml:"allowed_users"`
+	AllowedGroups *[]string `yaml:"allowed_groups"`
+	Input         []Input   `yaml:"input"`
 }
 
 type Input struct {
@@ -171,6 +173,16 @@ type ResolvedTask struct {
 	Input         []Input
 }
 
+func (d TaskDefaults) isZero() bool {
+	return d.Timeout == "" &&
+		d.MaxRetry == 0 &&
+		d.RetryDelay == "" &&
+		d.Queue == "" &&
+		d.LogRetention == "" &&
+		len(d.AllowedUsers) == 0 &&
+		len(d.AllowedGroups) == 0
+}
+
 func Load(path string) (*TasksConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -249,7 +261,7 @@ func loadInclude(cfg *TasksConfig, path string, taskSources map[string]string) e
 	if len(included.Include) > 0 {
 		return fmt.Errorf("included file %q must not define include", path)
 	}
-	if included.Defaults != (TaskDefaults{}) {
+	if !included.Defaults.isZero() {
 		return fmt.Errorf("included file %q must not define defaults", path)
 	}
 
@@ -331,6 +343,16 @@ func (c *TasksConfig) Resolve(name string) (*ResolvedTask, error) {
 		queue = "default"
 	}
 
+	allowedUsers := c.Defaults.AllowedUsers
+	if task.AllowedUsers != nil {
+		allowedUsers = *task.AllowedUsers
+	}
+
+	allowedGroups := c.Defaults.AllowedGroups
+	if task.AllowedGroups != nil {
+		allowedGroups = *task.AllowedGroups
+	}
+
 	return &ResolvedTask{
 		Name:          name,
 		Script:        task.Script,
@@ -339,8 +361,8 @@ func (c *TasksConfig) Resolve(name string) (*ResolvedTask, error) {
 		MaxRetry:      maxRetry,
 		RetryDelay:    retryDelayDur,
 		Queue:         queue,
-		AllowedUsers:  task.AllowedUsers,
-		AllowedGroups: task.AllowedGroups,
+		AllowedUsers:  allowedUsers,
+		AllowedGroups: allowedGroups,
 		Input:         task.Input,
 	}, nil
 }

--- a/internal/tasks/tasks_test.go
+++ b/internal/tasks/tasks_test.go
@@ -221,6 +221,7 @@ defaults:
   timeout: 5m
   max_retry: 3
   queue: default
+  allowed_groups: [platform]
 
 tasks:
   test:
@@ -258,6 +259,14 @@ tasks:
 
 	if len(task.Input) != 1 {
 		t.Errorf("expected 1 input, got %d", len(task.Input))
+	}
+
+	resolved, err := cfg.Resolve("test")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if len(resolved.AllowedGroups) != 1 || resolved.AllowedGroups[0] != "platform" {
+		t.Errorf("expected inherited AllowedGroups [platform], got %v", resolved.AllowedGroups)
 	}
 }
 
@@ -316,13 +325,20 @@ func TestTasksConfigResolve(t *testing.T) {
 
 	t.Run("resolve allowed_groups", func(t *testing.T) {
 		cfgWithGroups := &TasksConfig{
+			Defaults: TaskDefaults{
+				AllowedGroups: []string{"platform"},
+			},
 			Tasks: map[string]TaskDef{
 				"restricted": {
 					Script:        "restricted.sh",
-					AllowedGroups: []string{"admin", "ops"},
+					AllowedGroups: &[]string{"admin", "ops"},
 				},
 				"open": {
-					Script: "open.sh",
+					Script:        "open.sh",
+					AllowedGroups: &[]string{},
+				},
+				"inherited": {
+					Script: "inherited.sh",
 				},
 			},
 		}
@@ -342,19 +358,33 @@ func TestTasksConfigResolve(t *testing.T) {
 		if len(resolved.AllowedGroups) != 0 {
 			t.Errorf("expected empty AllowedGroups, got %v", resolved.AllowedGroups)
 		}
+
+		resolved, err = cfgWithGroups.Resolve("inherited")
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+		if len(resolved.AllowedGroups) != 1 || resolved.AllowedGroups[0] != "platform" {
+			t.Errorf("expected inherited AllowedGroups [platform], got %v", resolved.AllowedGroups)
+		}
 	})
 
 	t.Run("resolve allowed_users", func(t *testing.T) {
 		cfg := &TasksConfig{
+			Defaults: TaskDefaults{
+				AllowedUsers: []string{"platform-bot"},
+			},
 			Tasks: map[string]TaskDef{
 				"sa-only": {
 					Script:       "sa.sh",
-					AllowedUsers: []string{"system:serviceaccount:rdsma:sertdxkkk"},
+					AllowedUsers: &[]string{"system:serviceaccount:rdsma:sertdxkkk"},
 				},
 				"both": {
 					Script:        "both.sh",
-					AllowedUsers:  []string{"alice"},
-					AllowedGroups: []string{"ops"},
+					AllowedUsers:  &[]string{"alice"},
+					AllowedGroups: &[]string{"ops"},
+				},
+				"inherited": {
+					Script: "inherited.sh",
 				},
 			},
 		}
@@ -376,6 +406,14 @@ func TestTasksConfigResolve(t *testing.T) {
 		}
 		if len(resolved.AllowedGroups) != 1 || resolved.AllowedGroups[0] != "ops" {
 			t.Errorf("expected AllowedGroups [ops], got %v", resolved.AllowedGroups)
+		}
+
+		resolved, err = cfg.Resolve("inherited")
+		if err != nil {
+			t.Fatalf("Resolve() error = %v", err)
+		}
+		if len(resolved.AllowedUsers) != 1 || resolved.AllowedUsers[0] != "platform-bot" {
+			t.Errorf("expected inherited AllowedUsers [platform-bot], got %v", resolved.AllowedUsers)
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- add `defaults.allowed_users` and `defaults.allowed_groups` support for task configs
- apply default authorization when a task does not define the matching task-level authorization field
- keep task-level authorization as the override, including explicit `[]` to clear a default for one task
- document default task authorization behavior and override semantics

## Tests
- `go test ./...`
- covered task resolution for inherited `defaults.allowed_groups`
- covered task resolution for inherited `defaults.allowed_users`
- covered task-level `allowed_groups` / `allowed_users` overriding defaults
- covered explicit empty task-level authorization lists clearing defaults
- covered API submit authorization for inherited default groups: matching group is accepted, non-member is rejected
- covered API submit authorization for inherited default users: matching identity is accepted, non-member is rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable default authorization rules that apply to all tasks, with the ability to override defaults per task.

* **Documentation**
  * Updated authorization documentation to clarify default and task-level override behavior for users and groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->